### PR TITLE
Updated Vite Proxy

### DIFF
--- a/.github/workflows/secrets-detection.yaml
+++ b/.github/workflows/secrets-detection.yaml
@@ -47,14 +47,8 @@ jobs:
                     detect-secrets scan --disable-plugin AbsolutePathDetectorExperimental --baseline .secrets.new \
                         --exclude-files '\.secrets..*' \
                         --exclude-files '\.git.*' \
-                        --exclude-files '\.mypy_cache' \
-                        --exclude-files '\.pytest_cache' \
-                        --exclude-files '\.tox' \
-                        --exclude-files '\.venv' \
-                        --exclude-files 'venv' \
                         --exclude-files 'dist' \
-                        --exclude-files 'build' \
-                        --exclude-files '.*\.egg-info'
+                        --exclude-files 'node_modules'
 
                     # if there is any difference between the known and newly detected secrets, break the build
                     # Function to compare secrets without listing them

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2,9 +2,6 @@
   "version": "1.4.0",
   "plugins_used": [
     {
-      "name": "AbsolutePathDetectorExperimental"
-    },
-    {
       "name": "ArtifactoryDetector"
     },
     {
@@ -88,10 +85,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -128,219 +121,63 @@
         "\\.secrets..*",
         "\\.git.*",
         "\\.pre-commit-config\\.yaml",
-        "target",
-        "wordpress/data/wp-includes/",
-        "wordpress/data/wp-admin/js/",
-        "wordpress/data/wp-content/plugins/",
-        "wordpress/data/wp-content/themes/"
+        "\\.mypy_cache",
+        "\\.pytest_cache",
+        "\\.tox",
+        "\\.venv",
+        "venv",
+        "dist",
+        "build",
+        ".*\\.egg-info"
       ]
     }
   ],
   "results": {
-    "db/Dockerfile": [
+    "apps/backend/nasa-pds-wp/Dockerfile": [
       {
         "type": "Email Address",
-        "filename": "db/Dockerfile",
+        "filename": "apps/backend/nasa-pds-wp/Dockerfile",
         "hashed_secret": "11fc200a07fe0ef7ec81c56650ae875a874e2306",
         "is_verified": false,
-        "line_number": 2,
-        "is_secret": false
+        "line_number": 2
       }
     ],
-    "frontend/Dockerfile": [
+    "apps/backend/nasa-pds-wp/themes/twentytwentythree/assets/fonts/dm-sans/LICENSE.txt": [
       {
         "type": "Email Address",
-        "filename": "frontend/Dockerfile",
+        "filename": "apps/backend/nasa-pds-wp/themes/twentytwentythree/assets/fonts/dm-sans/LICENSE.txt",
+        "hashed_secret": "cab1a4d0749a54dbc2a7f27739ceb91718b44b35",
+        "is_verified": false,
+        "line_number": 1
+      }
+    ],
+    "apps/backend/nasa-pds-wp/themes/twentytwentythree/readme.txt": [
+      {
+        "type": "Email Address",
+        "filename": "apps/backend/nasa-pds-wp/themes/twentytwentythree/readme.txt",
+        "hashed_secret": "cab1a4d0749a54dbc2a7f27739ceb91718b44b35",
+        "is_verified": false,
+        "line_number": 57
+      }
+    ],
+    "apps/db/Dockerfile": [
+      {
+        "type": "Email Address",
+        "filename": "apps/db/Dockerfile",
         "hashed_secret": "11fc200a07fe0ef7ec81c56650ae875a874e2306",
         "is_verified": false,
-        "line_number": 2,
-        "is_secret": false
+        "line_number": 2
       }
     ],
-    "wordpress/Dockerfile": [
+    "apps/frontend/Dockerfile": [
       {
         "type": "Email Address",
-        "filename": "wordpress/Dockerfile",
+        "filename": "apps/frontend/Dockerfile",
         "hashed_secret": "11fc200a07fe0ef7ec81c56650ae875a874e2306",
         "is_verified": false,
-        "line_number": 2,
-        "is_secret": false
-      }
-    ],
-    "wordpress/data/wp-admin/includes/class-ftp.php": [
-      {
-        "type": "Email Address",
-        "filename": "wordpress/data/wp-admin/includes/class-ftp.php",
-        "hashed_secret": "ea6bba7480e97614daa339407ae21fef4a4607d2",
-        "is_verified": false,
-        "line_number": 147,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "wordpress/data/wp-admin/includes/class-ftp.php",
-        "hashed_secret": "ea6bba7480e97614daa339407ae21fef4a4607d2",
-        "is_verified": false,
-        "line_number": 147,
-        "is_secret": false
-      },
-      {
-        "type": "Email Address",
-        "filename": "wordpress/data/wp-admin/includes/class-ftp.php",
-        "hashed_secret": "70fc749f4dc55e9f9c5ed2ca9cf7fddb315fa071",
-        "is_verified": false,
-        "line_number": 365,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "wordpress/data/wp-admin/includes/class-ftp.php",
-        "hashed_secret": "70fc749f4dc55e9f9c5ed2ca9cf7fddb315fa071",
-        "is_verified": false,
-        "line_number": 365,
-        "is_secret": false
-      }
-    ],
-    "wordpress/data/wp-admin/includes/file.php": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "wordpress/data/wp-admin/includes/file.php",
-        "hashed_secret": "c654f0f644f01b176c2fa3413adfdb14f135a041",
-        "is_verified": false,
-        "line_number": 1551,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "wordpress/data/wp-admin/includes/file.php",
-        "hashed_secret": "92ca30b9103707cd2d8ccbab3b8664496e3f8953",
-        "is_verified": false,
-        "line_number": 2351,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "wordpress/data/wp-admin/includes/file.php",
-        "hashed_secret": "a38465feaeb66752e0a9766cf9e2c78ef14a6c09",
-        "is_verified": false,
-        "line_number": 2353,
-        "is_secret": false
-      }
-    ],
-    "wordpress/data/wp-admin/includes/list-table.php": [
-      {
-        "type": "Secret Keyword",
-        "filename": "wordpress/data/wp-admin/includes/list-table.php",
-        "hashed_secret": "cbfd2c1b76356f00e0c390a62d937bad0c3790e3",
-        "is_verified": false,
-        "line_number": 35,
-        "is_secret": false
-      }
-    ],
-    "wordpress/data/wp-admin/includes/schema.php": [
-      {
-        "type": "Email Address",
-        "filename": "wordpress/data/wp-admin/includes/schema.php",
-        "hashed_secret": "50e2b46ef8778549445c9610f4fea207d995c937",
-        "is_verified": false,
-        "line_number": 416,
-        "is_secret": false
-      },
-      {
-        "type": "Email Address",
-        "filename": "wordpress/data/wp-admin/includes/schema.php",
-        "hashed_secret": "df2faf0d7c2ad4f60b41adb933d6c82be2ab7d21",
-        "is_verified": false,
-        "line_number": 426,
-        "is_secret": false
-      }
-    ],
-    "wordpress/data/wp-admin/install.php": [
-      {
-        "type": "Email Address",
-        "filename": "wordpress/data/wp-admin/install.php",
-        "hashed_secret": "59614f92093fc9fef50673bc160fd808623b17bd",
-        "is_verified": false,
-        "line_number": 419,
-        "is_secret": false
-      }
-    ],
-    "wordpress/data/wp-admin/network/site-new.php": [
-      {
-        "type": "Secret Keyword",
-        "filename": "wordpress/data/wp-admin/network/site-new.php",
-        "hashed_secret": "08d2e98e6754af941484848930ccbaddfefe13d6",
-        "is_verified": false,
-        "line_number": 111,
-        "is_secret": false
-      }
-    ],
-    "wordpress/data/wp-config.php": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "wordpress/data/wp-config.php",
-        "hashed_secret": "44709fb398ea52bdd02c7d29668d245251f595c0",
-        "is_verified": false,
-        "line_number": 78,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "wordpress/data/wp-config.php",
-        "hashed_secret": "52014ac5303830c79c13a8cf5ffdea2a2b1dd166",
-        "is_verified": false,
-        "line_number": 79,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "wordpress/data/wp-config.php",
-        "hashed_secret": "fe3475091b4189008d188698208b41f35a0ed804",
-        "is_verified": false,
-        "line_number": 80,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "wordpress/data/wp-config.php",
-        "hashed_secret": "85b25c6f8679cfbb92c6b03815a82d057fa30779",
-        "is_verified": false,
-        "line_number": 81,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "wordpress/data/wp-config.php",
-        "hashed_secret": "28ee37bf3eacf2137ec4e1236ce04fdd30ba4996",
-        "is_verified": false,
-        "line_number": 82,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "wordpress/data/wp-config.php",
-        "hashed_secret": "08d4f2b66fe290713af06a1d195d010fea46138a",
-        "is_verified": false,
-        "line_number": 83,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "wordpress/data/wp-config.php",
-        "hashed_secret": "2e43fc93bdf6cf448b9039c86fb305bd195a9447",
-        "is_verified": false,
-        "line_number": 84,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "wordpress/data/wp-config.php",
-        "hashed_secret": "c9a341e22f81b4165b1b81dc91d5b480826825cc",
-        "is_verified": false,
-        "line_number": 85,
-        "is_secret": false
+        "line_number": 2
       }
     ]
   },
-  "generated_at": "2024-04-15T19:57:42Z"
+  "generated_at": "2024-08-15T18:57:45Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2,6 +2,9 @@
   "version": "1.4.0",
   "plugins_used": [
     {
+      "name": "AbsolutePathDetectorExperimental"
+    },
+    {
       "name": "ArtifactoryDetector"
     },
     {
@@ -85,6 +88,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -121,14 +128,7 @@
         "\\.secrets..*",
         "\\.git.*",
         "\\.pre-commit-config\\.yaml",
-        "\\.mypy_cache",
-        "\\.pytest_cache",
-        "\\.tox",
-        "\\.venv",
-        "venv",
-        "dist",
-        "build",
-        ".*\\.egg-info"
+        "node_modules"
       ]
     }
   ],
@@ -139,7 +139,8 @@
         "filename": "apps/backend/nasa-pds-wp/Dockerfile",
         "hashed_secret": "11fc200a07fe0ef7ec81c56650ae875a874e2306",
         "is_verified": false,
-        "line_number": 2
+        "line_number": 2,
+        "is_secret": false
       }
     ],
     "apps/backend/nasa-pds-wp/themes/twentytwentythree/assets/fonts/dm-sans/LICENSE.txt": [
@@ -148,7 +149,8 @@
         "filename": "apps/backend/nasa-pds-wp/themes/twentytwentythree/assets/fonts/dm-sans/LICENSE.txt",
         "hashed_secret": "cab1a4d0749a54dbc2a7f27739ceb91718b44b35",
         "is_verified": false,
-        "line_number": 1
+        "line_number": 1,
+        "is_secret": false
       }
     ],
     "apps/backend/nasa-pds-wp/themes/twentytwentythree/readme.txt": [
@@ -157,7 +159,8 @@
         "filename": "apps/backend/nasa-pds-wp/themes/twentytwentythree/readme.txt",
         "hashed_secret": "cab1a4d0749a54dbc2a7f27739ceb91718b44b35",
         "is_verified": false,
-        "line_number": 57
+        "line_number": 57,
+        "is_secret": false
       }
     ],
     "apps/db/Dockerfile": [
@@ -166,7 +169,8 @@
         "filename": "apps/db/Dockerfile",
         "hashed_secret": "11fc200a07fe0ef7ec81c56650ae875a874e2306",
         "is_verified": false,
-        "line_number": 2
+        "line_number": 2,
+        "is_secret": false
       }
     ],
     "apps/frontend/Dockerfile": [
@@ -175,9 +179,10 @@
         "filename": "apps/frontend/Dockerfile",
         "hashed_secret": "11fc200a07fe0ef7ec81c56650ae875a874e2306",
         "is_verified": false,
-        "line_number": 2
+        "line_number": 2,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2024-08-15T18:57:45Z"
+  "generated_at": "2024-08-15T21:25:51Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ export WPCLI_CONTAINER_NAME = ${NAME_PREFIX}-wpcli
 export RUN_OPTIONS = 
 export DOCKER_COMPOSE_YML = ./apps/docker-compose.yml
 
+# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Docker Recipes
+
 build:		## Builds all services using Docker Compose
 	docker compose --file ${DOCKER_COMPOSE_YML} build
 
@@ -119,6 +123,24 @@ stop-wpcli:		## Stops running wpcli service
 
 watch-containers:		## Display a list of running containers that refreshes periodically
 	watch docker container ls
+
+# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Secrets Detection Receipes
+# 
+# Reference:
+# https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Git-and-Github-Guide#detect-secrets
+#
+
+audit-secrets:	## Audit .secrets.baseline
+	detect-secrets audit .secrets.baseline
+
+update-secrets-baseline:	## Updates .secrets.baseline
+	detect-secrets scan --disable-plugin AbsolutePathDetectorExperimental \
+		--exclude-files '\.secrets..*' \
+		--exclude-files '\.git.*' \
+		--exclude-files '\.pre-commit-config\.yaml' \
+		--exclude-files 'node_modules' > .secrets.baseline
 
 # ----------------------------------------------------------------------------
 # Self-Documented Makefile

--- a/apps/frontend/src/pages/investigations/detail.tsx
+++ b/apps/frontend/src/pages/investigations/detail.tsx
@@ -288,6 +288,7 @@ const InvestigationDetailBody = (props:InvestigationDetailBodyProps) => {
         let query = '/api/search/1/products?q=(pds:Internal_Reference.pds:lid_reference eq "' + lid + '" and product_class eq "Product_Bundle")';
         const config = {
           headers: {
+            "Accept": "application/json",
             "Content-Type": "application/json",
           },
           signal: abortController.signal

--- a/apps/frontend/src/state/slices/instrumentHostsSlice.ts
+++ b/apps/frontend/src/state/slices/instrumentHostsSlice.ts
@@ -36,6 +36,7 @@ export const getInstrumentHosts = createAsyncThunk(
     let queryUrl = '/api/search/1/products?q=(lid like "urn:nasa:pds:context:instrument_host:*")&limit=9999'
     const config = {
       headers: {
+        "Accept": "application/json",
         "Content-Type": "application/json",
       }
     };

--- a/apps/frontend/src/state/slices/instrumentsSlice.ts
+++ b/apps/frontend/src/state/slices/instrumentsSlice.ts
@@ -36,6 +36,7 @@ export const getInstruments = createAsyncThunk(
     let queryUrl = '/api/search/1/products?q=(lid like "urn:nasa:pds:context:instrument:*")&limit=9999'
     const config = {
       headers: {
+        "Accept": "application/json",
         "Content-Type": "application/json",
       }
     };

--- a/apps/frontend/src/state/slices/investigationsSlice.ts
+++ b/apps/frontend/src/state/slices/investigationsSlice.ts
@@ -44,6 +44,7 @@ export const getInvestigations = createAsyncThunk(
     let queryUrl = '/api/search/1/products?q=(lid like "urn:nasa:pds:context:investigation:*")&limit=9999'
     const config = {
       headers: {
+        "Accept": "application/json",
         "Content-Type": "application/json",
       }
     };

--- a/apps/frontend/src/state/slices/targetsSlice.ts
+++ b/apps/frontend/src/state/slices/targetsSlice.ts
@@ -36,6 +36,7 @@ export const getTargets = createAsyncThunk(
     let queryUrl = '/api/search/1/products?q=(lid like "urn:nasa:pds:context:target:*")&limit=9999'
     const config = {
       headers: {
+        "Accept": "application/json",
         "Content-Type": "application/json",
       }
     };

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -14,9 +14,10 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      "/api": {
-        target: "https://pds.nasa.gov/",
+      "^/api/search/1/": {
+        target: "http://localhost:8080/",
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/search\/1/i, ''),
       }
     }
   },


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

The Vite proxy has been updated so that requests for information from the API are fetched from a locally running instance of the registry.  An accept header was also added to all data requests to resolve an error being reported by the API about invalid data type being requested.

Note: this only affects local development.

## ⚙️ Test Data and/or Report

Verified dev proxy configuration is working by running the dev server locally and ensuring that data could be retrieved from the locally running instance of the registry.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Fixes #11 

