### PR TITLE
Update vite configuration to resolve warning

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "portal/",
+  base: "/portal/",
   envDir: ".env",
   plugins: [
     react(),


### PR DESCRIPTION

<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

Added leading slash to 'base' configuration in vite.config.ts to resolve ""base" option should start with a slash." warning being reported when using `npm run preview`.

## ⚙️ Test Data and/or Report

Local builds and preview do not generated errors or warnings.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

#35 
