### PR TITLE
Fix Search Result Title Display

### DIFF
--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -987,7 +987,7 @@ const SearchPage = () => {
                             <Box>
                               {getDocType(doc) === "databundle" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1073,7 +1073,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "datacollection" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1161,7 +1161,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "dataset" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1233,7 +1233,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "facility" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.facility_description
                                       ? doc.facility_description[0]
@@ -1283,7 +1283,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "instrument" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.instrument_description
                                       ? doc.instrument_description[0]
@@ -1332,7 +1332,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "instrument_host" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.instrument_host_description
                                       ? doc.instrument_host_description[0]
@@ -1400,7 +1400,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "investigation" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.investigation_description
                                       ? doc.investigation_description[0]
@@ -1471,7 +1471,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "resource" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1508,7 +1508,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "target" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1546,7 +1546,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "telescope" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.telescope_description
                                       ? doc.telescope_description[0]
@@ -1591,7 +1591,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "tool" ? (
                                 <FeaturedLink
-                                  title={doc.title}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1642,7 +1642,8 @@ const SearchPage = () => {
                               {getDocType(doc) === "" ? (
                                 <Box>
                                   <p>
-                                    This doc type is not supported: {doc.title}.
+                                    This doc type is not supported:{" "}
+                                    {doc.title ? doc.title[0] : "-"}.
                                     product_class: {doc.product_class}.
                                     data_class: {doc.data_class}.{" "}
                                   </p>


### PR DESCRIPTION
## 🗒️ Summary
Fixes a bug where titles were showing the entire contents of an array instead of only the first item in the array.

## ⚙️ Test Data and/or Report
Run normally as instructed in the read me.

## ♻️ Related Issues