### PR TITLE
Fix search result linking for investigations

### DIFF
--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -657,7 +657,7 @@ const SearchPage = () => {
     const params = {
       lid,
     };
-    return generatePath("/investigations/:lid/data", params);
+    return generatePath("/investigations/:lid/instruments", params);
   };
 
   const getInstrumentPath = (lid: string) => {


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

This PR addresses the fix needed to link to a valid tab on the investigations page from the search results page.

## ⚙️ Test Data and/or Report

Tested fix locally.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

#72 

