### PR TITLE
Use Facet Titles Instead Of Names #68

### DIFF
--- a/apps/frontend/src/components/HomeSearch/HomeSearch.scss
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.scss
@@ -88,4 +88,5 @@
 .pds-home-page-filter-option-text .MuiTypography-root.MuiTypography-body1.MuiListItemText-primary{
     font-size: 14px;
     text-transform: uppercase;
+    text-wrap: auto;
 }

--- a/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
@@ -60,13 +60,13 @@ const getFiltersQuery =
   "?q=*&qt=keyword&rows=0&facet=on&facet.field=investigation_ref&facet.field=instrument_ref&facet.field=target_ref&facet.field=page_type&wt=json&facet.limit=-1";
 const investigationNamesEndpoint =
   solrEndpoint +
-  "?wt=json&qt=keyword&q=data_class:Investigation&fl=investigation_name,identifier&rows=10000";
+  "?wt=json&qt=keyword&q=data_class:Investigation&fl=title,identifier&rows=10000";
 const instrumentNamesEndpoint =
   solrEndpoint +
-  "?wt=json&qt=keyword&q=data_class:Instrument&fl=instrument_name,identifier&rows=10000";
+  "?wt=json&qt=keyword&q=data_class:Instrument&fl=title,identifier&rows=10000";
 const targetNamesEndpoint =
   solrEndpoint +
-  "?wt=json&qt=keyword&q=data_class:Target&fl=target_name,identifier&rows=10000";
+  "?wt=json&qt=keyword&q=data_class:Target&fl=title,identifier&rows=10000";
 
 type Filter = {
   name: string;

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -73,13 +73,13 @@ const getFiltersQuery =
   "&qt=keyword&rows=0&facet=on&facet.field=investigation_ref&facet.field=instrument_ref&facet.field=target_ref&facet.field=page_type&wt=json&facet.limit=-1";
 const investigationNamesEndpoint =
   solrEndpoint +
-  "?wt=json&qt=keyword&q=data_class:Investigation&fl=investigation_name,identifier&rows=10000";
+  "?wt=json&qt=keyword&q=data_class:Investigation&fl=title,identifier&rows=10000";
 const instrumentNamesEndpoint =
   solrEndpoint +
-  "?wt=json&qt=keyword&q=data_class:Instrument&fl=instrument_name,identifier&rows=10000";
+  "?wt=json&qt=keyword&q=data_class:Instrument&fl=title,identifier&rows=10000";
 const targetNamesEndpoint =
   solrEndpoint +
-  "?wt=json&qt=keyword&q=data_class:Target&fl=target_name,identifier&rows=10000";
+  "?wt=json&qt=keyword&q=data_class:Target&fl=title,identifier&rows=10000";
 
 const linkStyles = {
   fontFamily: "Inter",

--- a/apps/frontend/src/pages/search/searchUtils.ts
+++ b/apps/frontend/src/pages/search/searchUtils.ts
@@ -252,14 +252,8 @@ export const mapFilterIdsToName = (ids: string[], names: IdentifierNameDoc[]) =>
         if (nameDoc) {
           let name: string = "";
 
-          if (nameDoc.investigation_name) {
-            name = nameDoc.investigation_name[0];
-          }
-          if (nameDoc.instrument_name) {
-            name = nameDoc.instrument_name[0];
-          }
-          if (nameDoc.target_name) {
-            name = nameDoc.target_name[0];
+          if (nameDoc.title) {
+            name = nameDoc.title[0];
           }
 
           filtersMap.push({

--- a/apps/frontend/src/types/solrSearchResponse.d.ts
+++ b/apps/frontend/src/types/solrSearchResponse.d.ts
@@ -118,6 +118,7 @@ type IdentifierNameDoc = {
     investigation_name: string[];
     instrument_name: string[];
     target_name: string[];
+    title: string[];
 }
 
 type ResponseHeader = {


### PR DESCRIPTION
## 🗒️ Summary
This Pull request changes facets to use the title value for display instead of the name which is sometimes missing. 
It also adds a style to wrap facet names in the home page drop downs.


## ⚙️ Test Data and/or Report
Run this branch normally as stated in the read me. Observe the facet drop downs in the home page and the facet names in the search page.

## ♻️ Related Issues
fixes #68


