### PR TITLE
Show Facet Counts In Search Page Filters

### DIFF
--- a/apps/frontend/src/components/Filters/Filter.tsx
+++ b/apps/frontend/src/components/Filters/Filter.tsx
@@ -144,6 +144,10 @@ const Filter = ({
                 />
                 <Typography variant="h6" weight="regular">
                   {option.title.toUpperCase()}
+
+                  {option.title === "all"
+                    ? ""
+                    : "(" + option.resultsFound + ")"}
                 </Typography>
               </Box>
             ) : (

--- a/apps/frontend/src/components/Filters/Filter.tsx
+++ b/apps/frontend/src/components/Filters/Filter.tsx
@@ -145,9 +145,11 @@ const Filter = ({
                 <Typography variant="h6" weight="regular">
                   {option.title.toUpperCase()}
 
-                  {option.title === "all"
-                    ? ""
-                    : "(" + option.resultsFound + ")"}
+                  <span className="pds-search-filter-count-span ">
+                    {option.title === "all"
+                      ? ""
+                      : " (" + option.resultsFound + ")"}
+                  </span>
                 </Typography>
               </Box>
             ) : (

--- a/apps/frontend/src/components/Filters/filter.scss
+++ b/apps/frontend/src/components/Filters/filter.scss
@@ -42,3 +42,7 @@
 .pds-search-filter-dropdown-button-grid{
    text-align: right;
 }
+
+.pds-search-filter-count-span {
+   color: var(--pds-secondary-white-s4);
+}

--- a/apps/frontend/src/pages/search/searchUtils.ts
+++ b/apps/frontend/src/pages/search/searchUtils.ts
@@ -1,5 +1,4 @@
 import {
-    Facetfields,
     IdentifierNameDoc,
     SolrSearchResponse,
     SolrIdentifierNameResponse,

--- a/apps/frontend/src/pages/search/searchUtils.ts
+++ b/apps/frontend/src/pages/search/searchUtils.ts
@@ -1,4 +1,5 @@
 import {
+    Facetfields,
     IdentifierNameDoc,
     SolrSearchResponse,
     SolrIdentifierNameResponse,
@@ -241,13 +242,24 @@ export const isOptionChecked = (
     return isOptionChecked;
 };
 
-export const mapFilterIdsToName = (ids: string[], names: IdentifierNameDoc[]) => {
-    const filtersMap: { name: string; identifier: string }[] = [];
+export const mapFilterIdsToName = (ids: string[], names: IdentifierNameDoc[], searchResultFacets?: (number | string)[]) => {
+    const filtersMap: { name: string; identifier: string, count: string }[] = [];
 
     ids.forEach((id, index) => {
       if (index % 2 == 0) {
         const urnSplit = id.split("::")[0];
         const nameDoc = names.find((name) => name.identifier[0] === urnSplit);
+        let count = ids[index + 1];
+
+        if(searchResultFacets){
+            const searchResultFacetIndex = searchResultFacets.indexOf(urnSplit);
+            if(searchResultFacetIndex === -1){
+                count = "0";
+            }
+            else{
+                count = String(searchResultFacets[searchResultFacetIndex + 1]);
+            }
+        }
 
         if (nameDoc) {
           let name: string = "";
@@ -259,6 +271,7 @@ export const mapFilterIdsToName = (ids: string[], names: IdentifierNameDoc[]) =>
           filtersMap.push({
             name,
             identifier: id,
+            count
           });
         }
       }
@@ -267,13 +280,29 @@ export const mapFilterIdsToName = (ids: string[], names: IdentifierNameDoc[]) =>
     return filtersMap;
 };
 
-export const mapPageType = (ids: string[]) => {
-    const filtersMap: { name: string; identifier: string }[] = [];
+export const mapPageType = (ids: string[], searchResultFacets?: (number | string)[]) => {
+    const filtersMap: { name: string; identifier: string, count: string }[] = [];
         ids.forEach((id, index) => {
             if (index % 2 == 0) {
+                let count = ids[index + 1];
+
+                if(searchResultFacets){
+                    const searchResultFacetIndex = searchResultFacets.indexOf(id);
+                    if(searchResultFacetIndex === -1){
+                        count = "0";
+                    }
+                    else{
+                        count = String(searchResultFacets[searchResultFacetIndex + 1]);
+                    }
+                    
+        
+                    //count = searchResultFacets.find((facet) => facet.identifier[0] === urnSplit)
+                }
+
                 filtersMap.push({
                     name: id,
                     identifier: id,
+                    count
                 });
             }
     });

--- a/apps/frontend/src/types/solrSearchResponse.d.ts
+++ b/apps/frontend/src/types/solrSearchResponse.d.ts
@@ -10,14 +10,14 @@ export type SolrIdentifierNameResponse = {
     facet_counts: Facetcounts;
 }
 
-type Facetcounts = {
+export type Facetcounts = {
     facet_queries: Facetqueries;
     facet_fields: Facetfields;
     facet_dates: Facetqueries;
     facet_ranges: Facetqueries;
 }
 
-type Facetfields = {
+export type Facetfields = {
     facet_pds_model_version: (number | string)[];
     facet_agency: (number | string)[];
     facet_type: (number | string)[];


### PR DESCRIPTION
## 🗒️ Summary
This PR adds filter counts for each filter option in the search page.

## ⚙️ Test Data and/or Report
Run normally.
Observe the filter count number next to each filter option in the search page.

## ♻️ Related Issues
fixes #69 


