### PR TITLE
Sorted Spacecraft list alphabetically for each Investigation on the Investigation's directory page.

### DIFF
--- a/apps/frontend/src/components/IndexedListComponent/InvestigationsIndexedListComponent.tsx
+++ b/apps/frontend/src/components/IndexedListComponent/InvestigationsIndexedListComponent.tsx
@@ -9,6 +9,7 @@ import { RootState, store } from "src/state/store";
 import { convertLogicalIdentifier, LID_FORMAT } from "src/utils/strings";
 import { ExpandMore } from "@mui/icons-material";
 import { FeaturedLink, FeaturedLinkDetails, FeaturedLinkDetailsVariant, Typography } from "@nasapds/wds-react";
+import { sortInstrumentHostsByTitle } from "src/utils/arrays";
 
 type InvestigationsIndexedListComponentProps = {
   investigations: Investigation[];
@@ -33,7 +34,7 @@ const getItemsByIndex = (
 };
 
 function getAffiliatedSpacecraft(state:RootState, investigation:Investigation) {
-  const instrumentHostTitles = selectLatestInstrumentHostsForInvestigation(state, investigation[PDS4_INFO_MODEL.REF_LID_INSTRUMENT_HOST])?.map(
+  const instrumentHostTitles = selectLatestInstrumentHostsForInvestigation(state, investigation[PDS4_INFO_MODEL.REF_LID_INSTRUMENT_HOST])?.sort(sortInstrumentHostsByTitle)?.map(
     (instrumentHost) => instrumentHost[PDS4_INFO_MODEL.TITLE]
   )
   return instrumentHostTitles;


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

Updated the investigations directory page so that the spacecraft listings for each Investigation are sorted alphabetically.

## ⚙️ Test Data and/or Report

Tested locally and ensured `npm run build` does not generated errors.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fixes #104 

