### PR TITLE
Add banner message to website to indicate to users that the site they are viewing is in beta

### DIFF
--- a/apps/frontend/src/AppConfig.ts
+++ b/apps/frontend/src/AppConfig.ts
@@ -1,9 +1,23 @@
 import { PROCESSING_LEVEL_KEYS } from "@nasapds/wds-react";
+import { BannerProps } from "@nasapds/wds-react";
 
-export const APP_CONFIG = {
+type AppConfig = {
+  GENERAL: {
+    VERSION:string
+    BANNER_MESSAGES:Array<BannerProps>
+  }
+  SETTINGS: {
+    SORT_ORDER: {
+      PROCESSING_LEVELS:Array<PROCESSING_LEVEL_KEYS>
+    }
+  }
+}
+
+export const APP_CONFIG:AppConfig = {
 
   GENERAL: {
-     VERSION: import.meta.env.VITE_APP_VERSION,
+    VERSION: import.meta.env.VITE_APP_VERSION,
+    BANNER_MESSAGES: []
   },
 
   SETTINGS: {

--- a/apps/frontend/src/AppConfig.ts
+++ b/apps/frontend/src/AppConfig.ts
@@ -17,7 +17,18 @@ export const APP_CONFIG:AppConfig = {
 
   GENERAL: {
     VERSION: import.meta.env.VITE_APP_VERSION,
-    BANNER_MESSAGES: []
+    BANNER_MESSAGES: [
+      {
+        title: "PDS is in Beta",
+        message: "As we work on improving the site, please keep in mind that it is still under development and may have limitations.",
+        link:{
+          title: "Give Feedback",
+          href: "mailto:pds-operator@jpl.nasa.gov",
+          type: "internal"
+        },
+        variant: "info"
+      }
+    ]
   },
 
   SETTINGS: {

--- a/apps/frontend/src/layouts/RootLayout.tsx
+++ b/apps/frontend/src/layouts/RootLayout.tsx
@@ -1,12 +1,27 @@
 import Header from "../components/Header/Header";
 import Footer from "../components/Footer/Footer";
+import { APP_CONFIG } from "src/AppConfig";
+import { Banner } from "@nasapds/wds-react";
 import { Outlet } from "react-router-dom";
 import { ScrollRestoration } from "react-router-dom";
 
 function RootLayout() {
 
+  const bannerMessages = APP_CONFIG["GENERAL"]["BANNER_MESSAGES"];
+
   return (
     <>
+      {
+        bannerMessages.map( (banner, bannerIndex) => {
+          return <Banner
+            title={banner.title}
+            message={banner.message}
+            link={banner.link}
+            variant={banner.variant}
+            key={"banner_" + bannerIndex}
+          />
+        })
+      }
       <Header />
       <div style={{ backgroundColor: "white", padding: "0px", color: "black" }}>
         {/* A "layout route" is a good place to put markup you want to


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

Added a banner message to the site using the newly created banner component so that users are informed that they are browsing a beta version of the site.

Companion PR containing banner component: https://github.com/NASA-PDS/wds-react/pull/77

## ⚙️ Test Data and/or Report

Tested locally and ensured that no errors are present when `npm run build` is executed.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fixes #90 

