### PR TITLE
Add Solr Warning #71

### DIFF
--- a/apps/frontend/src/components/Banner/SolrWarningBanner.tsx
+++ b/apps/frontend/src/components/Banner/SolrWarningBanner.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { Banner } from "@nasapds/wds-react";
+import { useLocation } from "react-router-dom";
+import { matchPath } from "react-router";
+import { formatSearchResults } from "../../pages/search/searchUtils";
+
+const solrEndpoint =
+  "https://pds.nasa.gov/services/search/search?wt=json&qt=keyword&q=*&rows=0&start=0";
+
+export type SolrWarningBannerProps = {
+  title: string;
+  message: string;
+  pages: string[];
+};
+
+export const SolrWarningBanner = (props: SolrWarningBannerProps) => {
+  const { title, message, pages } = props;
+  const location = useLocation();
+
+  const [isErrorDetected, setIsErrorDetected] = useState(false);
+
+  const checkPageService = async () => {
+    let routeMatch = false;
+    pages.forEach((path) => {
+      if (matchPath(path, location.pathname)) {
+        routeMatch = true;
+      }
+    });
+
+    if (routeMatch) {
+      fetch(solrEndpoint)
+        .then((response) => {
+          if (!response.ok) {
+            throw Error(response.statusText);
+          } else {
+            return response.json();
+          }
+        })
+        .then((data) => {
+          const formattedResults = formatSearchResults(data);
+
+          if (formattedResults.response.numFound <= 0) {
+            setIsErrorDetected(true);
+          }
+        })
+        .catch((error) => {
+          setIsErrorDetected(true);
+        });
+    }
+  };
+
+  useEffect(() => {
+    checkPageService();
+  }, [location]);
+
+  return (
+    <>
+      {isErrorDetected ? (
+        <Banner title={title} message={message} variant="alert" />
+      ) : (
+        <></>
+      )}
+    </>
+  );
+};

--- a/apps/frontend/src/components/Banner/SolrWarningBanner.tsx
+++ b/apps/frontend/src/components/Banner/SolrWarningBanner.tsx
@@ -45,6 +45,7 @@ export const SolrWarningBanner = (props: SolrWarningBannerProps) => {
         })
         .catch((error) => {
           setIsErrorDetected(true);
+          console.log(error);
         });
     }
   };

--- a/apps/frontend/src/layouts/RootLayout.tsx
+++ b/apps/frontend/src/layouts/RootLayout.tsx
@@ -1,5 +1,6 @@
 import Header from "../components/Header/Header";
 import Footer from "../components/Footer/Footer";
+import { SolrWarningBanner } from "../components/Banner/SolrWarningBanner.tsx";
 import { APP_CONFIG } from "src/AppConfig";
 import { Banner } from "@nasapds/wds-react";
 import { Outlet } from "react-router-dom";
@@ -22,6 +23,12 @@ function RootLayout() {
           />
         })
       }
+      <SolrWarningBanner
+        title="PDS Search is down for maintenance."
+        message="We expect it to be back shortly. Thanks for your patience."
+        pages={["/","/search","/search/:searchText"]}
+      />
+
       <Header />
       <div style={{ backgroundColor: "white", padding: "0px", color: "black" }}>
         {/* A "layout route" is a good place to put markup you want to


### PR DESCRIPTION
## 🗒️ Summary
This PR adds a warning when solr returns an error or no results on the home and search page.
<img width="1158" alt="Screenshot 2024-11-05 at 10 51 36 AM" src="https://github.com/user-attachments/assets/abbee721-e4f5-4eba-947c-15f265a3ca9c">


## ⚙️ Test Data and/or Report
Edit the SolrWarningBanner.tsx file to point to a non existent URL. Run normally and go to the home or search page. The error banner will appear.

## ♻️ Related Issues
fixes #71 


