### PR TITLE
Updated investigation title on instrument detail page so that it is a link that can navigate a user to the respective investigation detail page.

### DIFF
--- a/apps/frontend/src/components/IndexedListComponent/InstrumentsIndexedListComponent.tsx
+++ b/apps/frontend/src/components/IndexedListComponent/InstrumentsIndexedListComponent.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useState } from "react";
 import {Box, Container, Divider, Link, MenuItem, Select } from "@mui/material";
 import Grid from '@mui/material/Unstable_Grid2';
-import { generatePath, useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Instrument } from "src/types/instrument";
 import { PDS4_INFO_MODEL } from "src/types/pds4-info-model";
 import { selectLatestInstrumentHostsForInstrument, selectLatestInstrumentHostVersion, selectLatestInvestigationVersion } from "src/state/selectors";
 import { RootState, store } from "src/state/store";
 import { InstrumentHost } from "src/types/instrumentHost";
-import { convertLogicalIdentifier, LID_FORMAT } from "src/utils/strings";
 import { ExpandMore } from "@mui/icons-material";
 import { FeaturedLink, FeaturedLinkDetails, FeaturedLinkDetailsVariant, Typography } from "@nasapds/wds-react";
+import { getLinkToInstrumentDetailPage } from "src/utils/links";
 
 type InstrumentsIndexedListComponentProps = {
   instruments: Instrument[];
@@ -18,9 +18,7 @@ type InstrumentsIndexedListComponentProps = {
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 const OTHER_CHARS = "0123456789".split("");
 
-type InstrumentDetailPathParams = {
-  lid:string;
-}
+
 
 const getItemsByIndex = (
   arr: Instrument[],
@@ -55,18 +53,9 @@ function InstrumentsIndexedListComponent(props:InstrumentsIndexedListComponentPr
 
   const [indexValue, setIndexValue] = useState(location.hash.replace("#",""));
 
-  const instrumentListItemPrimaryPath = (params:InstrumentDetailPathParams) => {
-    params.lid = convertLogicalIdentifier(params.lid,LID_FORMAT.URL_FRIENDLY);
-    return generateLinkPath("/instruments/:lid/data", params);
-  };
-
   const scrollToIndex = (id:string) => {
     console.log("Set scroll to: ", id)
     setIndexValue(id);
-  }
-
-  const generateLinkPath = (template:string, params:{[key:string]:string}) => {
-    return generatePath(template, params)
   }
 
   const getInvestigationName = (instrument:Instrument):string => {
@@ -226,7 +215,7 @@ function InstrumentsIndexedListComponent(props:InstrumentsIndexedListComponentPr
                          <FeaturedLink
                           description={instrument[PDS4_INFO_MODEL.INSTRUMENT.DESCRIPTION]}
                           title={ instrument[PDS4_INFO_MODEL.TITLE] }
-                          primaryLink={ instrumentListItemPrimaryPath({ lid: instrument.lid }) }
+                          primaryLink={ getLinkToInstrumentDetailPage({ lid: instrument.lid }) }
                           columns={[
                             {
                               horizontalAlign: "center",
@@ -245,7 +234,7 @@ function InstrumentsIndexedListComponent(props:InstrumentsIndexedListComponentPr
                         >
                           <FeaturedLinkDetails 
                             investigation={{value:getInvestigationName(instrument)}}
-                            lid={{value: instrument[PDS4_INFO_MODEL.LID], link: instrumentListItemPrimaryPath({ lid: instrument.lid })}}
+                            lid={{value: instrument[PDS4_INFO_MODEL.LID], link: getLinkToInstrumentDetailPage({ lid: instrument.lid })}}
                             variant={FeaturedLinkDetailsVariant.INSTRUMENT}
                           />
                         </FeaturedLink>
@@ -282,7 +271,7 @@ function InstrumentsIndexedListComponent(props:InstrumentsIndexedListComponentPr
                         <FeaturedLink
                           description={instrument[PDS4_INFO_MODEL.INSTRUMENT.DESCRIPTION]}
                           title={ instrument[PDS4_INFO_MODEL.TITLE] }
-                          primaryLink={ instrumentListItemPrimaryPath({ lid: instrument.lid }) }
+                          primaryLink={ getLinkToInstrumentDetailPage({ lid: instrument.lid }) }
                           columns={[
                             {
                               horizontalAlign: "center",
@@ -301,7 +290,7 @@ function InstrumentsIndexedListComponent(props:InstrumentsIndexedListComponentPr
                         >
                           <FeaturedLinkDetails 
                             investigation={{value:getInvestigationName(instrument)}}
-                            lid={{value: instrument[PDS4_INFO_MODEL.LID], link: instrumentListItemPrimaryPath({ lid: instrument.lid })}}
+                            lid={{value: instrument[PDS4_INFO_MODEL.LID], link: getLinkToInstrumentDetailPage({ lid: instrument.lid })}}
                             variant={FeaturedLinkDetailsVariant.INSTRUMENT}
                           />
                         </FeaturedLink>

--- a/apps/frontend/src/components/IndexedListComponent/InvestigationsIndexedListComponent.tsx
+++ b/apps/frontend/src/components/IndexedListComponent/InvestigationsIndexedListComponent.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useState } from "react";
 import {Box, Container, Divider, Link, MenuItem, Select } from "@mui/material";
 import Grid from '@mui/material/Unstable_Grid2';
-import { generatePath, useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Investigation } from "src/types/investigation";
 import { PDS4_INFO_MODEL } from "src/types/pds4-info-model";
 import { selectLatestInstrumentHostsForInvestigation } from "src/state/selectors";
 import { RootState, store } from "src/state/store";
-import { convertLogicalIdentifier, LID_FORMAT } from "src/utils/strings";
 import { ExpandMore } from "@mui/icons-material";
 import { FeaturedLink, FeaturedLinkDetails, FeaturedLinkDetailsVariant, Typography } from "@nasapds/wds-react";
 import { sortInstrumentHostsByTitle } from "src/utils/arrays";
+import { getLinkToInvestigationDetailPage } from "src/utils/links";
 
 type InvestigationsIndexedListComponentProps = {
   investigations: Investigation[];
@@ -17,10 +17,6 @@ type InvestigationsIndexedListComponentProps = {
 
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 const OTHER_CHARS = "0123456789".split("");
-
-type InvestigationDetailPathParams = {
-  lid:string;
-}
 
 const getItemsByIndex = (
   arr: Investigation[],
@@ -49,18 +45,9 @@ function InvestigationsIndexedListComponent(props:InvestigationsIndexedListCompo
 
   const [indexValue, setIndexValue] = useState(location.hash.replace("#",""));
 
-  const investigationListItemPrimaryPath = (params:InvestigationDetailPathParams) => {
-    params.lid = convertLogicalIdentifier(params.lid,LID_FORMAT.URL_FRIENDLY);
-    return generateLinkPath("/investigations/:lid/instruments", params);
-  };
-
   const scrollToIndex = (id:string) => {
     console.log("Set scroll to: ", id)
     setIndexValue(id);
-  }
-
-  const generateLinkPath = (template:string, params:{[key:string]:string}) => {
-    return generatePath(template, params)
   }
 
   useEffect( () => {
@@ -199,7 +186,7 @@ function InvestigationsIndexedListComponent(props:InvestigationsIndexedListCompo
                          <FeaturedLink
                           description={investigation[PDS4_INFO_MODEL.INVESTIGATION.DESCRIPTION]}
                           title={ investigation[PDS4_INFO_MODEL.TITLE] }
-                          primaryLink={ investigationListItemPrimaryPath({ lid: investigation.lid }) }
+                          primaryLink={ getLinkToInvestigationDetailPage({ lid: investigation.lid }) }
                           columns={[
                             {
                               horizontalAlign: "center",
@@ -218,7 +205,7 @@ function InvestigationsIndexedListComponent(props:InvestigationsIndexedListCompo
                         >
                           <FeaturedLinkDetails 
                             instrumentHostTitles={getAffiliatedSpacecraft(state, investigation)}
-                            lid={{value: investigation[PDS4_INFO_MODEL.LID], link: investigationListItemPrimaryPath({ lid: investigation.lid })}}
+                            lid={{value: investigation[PDS4_INFO_MODEL.LID], link: getLinkToInvestigationDetailPage({ lid: investigation.lid })}}
                             startDate={{value:investigation[PDS4_INFO_MODEL.INVESTIGATION.START_DATE]}}
                             stopDate={{value:investigation[PDS4_INFO_MODEL.INVESTIGATION.STOP_DATE]}}
                             variant={FeaturedLinkDetailsVariant.INVESTIGATION}
@@ -258,7 +245,7 @@ function InvestigationsIndexedListComponent(props:InvestigationsIndexedListCompo
                         <FeaturedLink
                           description={investigation[PDS4_INFO_MODEL.INVESTIGATION.DESCRIPTION]}
                           title={ investigation[PDS4_INFO_MODEL.TITLE] }
-                          primaryLink={ investigationListItemPrimaryPath({ lid: investigation.lid }) }
+                          primaryLink={ getLinkToInvestigationDetailPage({ lid: investigation.lid }) }
                           columns={[
                             {
                               horizontalAlign: "center",
@@ -277,7 +264,7 @@ function InvestigationsIndexedListComponent(props:InvestigationsIndexedListCompo
                         >
                           <FeaturedLinkDetails 
                             instrumentHostTitles={getAffiliatedSpacecraft(state,investigation)}
-                            lid={{value: investigation[PDS4_INFO_MODEL.LID], link: investigationListItemPrimaryPath({ lid: investigation.lid })}}
+                            lid={{value: investigation[PDS4_INFO_MODEL.LID], link: getLinkToInvestigationDetailPage({ lid: investigation.lid })}}
                             startDate={{value: investigation[PDS4_INFO_MODEL.INVESTIGATION.START_DATE]}}
                             stopDate={{value:investigation[PDS4_INFO_MODEL.INVESTIGATION.STOP_DATE]}}
                             variant={FeaturedLinkDetailsVariant.INVESTIGATION}

--- a/apps/frontend/src/components/StatsList/StatsItem.tsx
+++ b/apps/frontend/src/components/StatsList/StatsItem.tsx
@@ -1,20 +1,37 @@
 import { Box, Divider, Typography } from "@mui/material"
 import { copyToClipboard } from "src/utils/strings";
+import { Link } from "react-router-dom";
 
 export type StatsItemProps = {
-  label:string,
-  value:string,
-  index:number,
   enableCopy:boolean
+  index:number,
+  label:string,
+  link?:string,
+  value:string,
 }
 
 export const StatsItem = ({
-  label,
-  value,
+  enableCopy = false,
   index,
-  enableCopy = false
+  label,
+  link,
+  value,
 }: StatsItemProps) => {
-  
+
+  let valueElement = <Typography id={'stat_'+index} sx={{
+    color: 'white',
+    fontSize: "14px",
+    fontFamily: 'Inter',
+    fontWeight: '600',
+    lineHeight: "19px",
+    wordWrap: 'break-word',
+    marginTop: "4px"
+  }}>{value}</Typography>;
+
+  if( link ) {
+    valueElement = <Link to={link}>{valueElement}</Link>;
+  }
+
   return (
     <Box sx={{
       minHeight: { md: "77px" },
@@ -34,15 +51,7 @@ export const StatsItem = ({
         wordWrap: 'break-word',
         marginTop: "8px"
       }}>{label}</Typography>
-      <Typography id={'stat_'+index} sx={{
-        color: 'white',
-        fontSize: "14px",
-        fontFamily: 'Inter',
-        fontWeight: '600',
-        lineHeight: "19px",
-        wordWrap: 'break-word',
-        marginTop: "4px"
-      }}>{value}</Typography>
+      {valueElement}
       {
         enableCopy && <Typography sx={{
             color: 'white',

--- a/apps/frontend/src/components/StatsList/StatsList.tsx
+++ b/apps/frontend/src/components/StatsList/StatsList.tsx
@@ -4,9 +4,10 @@ import StatsItem from './StatsItem';
 import React from 'react';
 
 export type Stats = {
-  label: string;
-  value: string;
   enableCopy?: boolean
+  label: string;
+  link?: string;
+  value: string;
 }
 
 type StatProps = {
@@ -25,7 +26,7 @@ export const StatsList = ({
               <Grid item xs={6} md={6} sx={{
                 marginTop: "24px"
               }}>
-                <StatsItem label={item.label} value={item.value} index={index} enableCopy={item.enableCopy || false} />
+                <StatsItem label={item.label} link={item.link} value={item.value} index={index} enableCopy={item.enableCopy || false} />
               </Grid>
             </React.Fragment>
         })

--- a/apps/frontend/src/pages/instruments/detail.tsx
+++ b/apps/frontend/src/pages/instruments/detail.tsx
@@ -27,6 +27,7 @@ import { selectLatestInstrumentHostVersion, selectLatestInvestigationVersion } f
 import { distinct, sortCollectionsByTitle } from "src/utils/arrays";
 import React from "react";
 import { APP_CONFIG } from "src/AppConfig";
+import { getLinkToInvestigation } from "src/utils/links";
 
 interface InstrumentDetailBodyProps {
   collections:Collection[];
@@ -200,6 +201,7 @@ const InstrumentDetailBody = (props:InstrumentDetailBodyProps) => {
   const stats:Stats[] = [
     {
       label: "Investigation",
+      link: getLinkToInvestigation({'lid': investigation[PDS4_INFO_MODEL.LID]}),
       value: investigation[PDS4_INFO_MODEL.TITLE] ? investigation[PDS4_INFO_MODEL.TITLE] : "Not available at this time"
     },
     {

--- a/apps/frontend/src/pages/instruments/detail.tsx
+++ b/apps/frontend/src/pages/instruments/detail.tsx
@@ -27,7 +27,7 @@ import { selectLatestInstrumentHostVersion, selectLatestInvestigationVersion } f
 import { distinct, sortCollectionsByTitle } from "src/utils/arrays";
 import React from "react";
 import { APP_CONFIG } from "src/AppConfig";
-import { getLinkToInvestigation } from "src/utils/links";
+import { getLinkToInvestigationDetailPage } from "src/utils/links";
 
 interface InstrumentDetailBodyProps {
   collections:Collection[];
@@ -201,7 +201,7 @@ const InstrumentDetailBody = (props:InstrumentDetailBodyProps) => {
   const stats:Stats[] = [
     {
       label: "Investigation",
-      link: getLinkToInvestigation({'lid': investigation[PDS4_INFO_MODEL.LID]}),
+      link: getLinkToInvestigationDetailPage({'lid': investigation[PDS4_INFO_MODEL.LID]}),
       value: investigation[PDS4_INFO_MODEL.TITLE] ? investigation[PDS4_INFO_MODEL.TITLE] : "Not available at this time"
     },
     {

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -15,6 +15,10 @@ import {
 } from "../../components/Filters/Filter";
 import { ellipsisText } from "../../utils/strings";
 import {
+  getLinkToInstrumentDetailPage,
+  getLinkToInvestigationDetailPage,
+} from "../../utils/links";
+import {
   Button as MuiButton,
   Box,
   Breadcrumbs,
@@ -62,7 +66,6 @@ import "./search.css";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 import { DocumentMeta } from "src/components/DocumentMeta/DocumentMeta";
-import { convertLogicalIdentifier, LID_FORMAT } from "src/utils/strings";
 
 const pdsSite = "https://pds.nasa.gov";
 const pdsIdViewer =
@@ -715,19 +718,11 @@ const SearchPage = () => {
   }, [params.searchText, searchParams]);
 
   const getInvestigationPath = (lid: string) => {
-    lid = convertLogicalIdentifier(lid, LID_FORMAT.URL_FRIENDLY);
-    const params = {
-      lid,
-    };
-    return generatePath("/investigations/:lid/instruments", params);
+    return getLinkToInvestigationDetailPage({ lid: lid });
   };
 
   const getInstrumentPath = (lid: string) => {
-    lid = convertLogicalIdentifier(lid, LID_FORMAT.URL_FRIENDLY);
-    const params = {
-      lid,
-    };
-    return generatePath("/instruments/:lid/data", params);
+    return getLinkToInstrumentDetailPage({ lid: lid });
   };
 
   const getDataBundlePath = (location: string) => {

--- a/apps/frontend/src/utils/links.ts
+++ b/apps/frontend/src/utils/links.ts
@@ -1,7 +1,11 @@
 import { generatePath } from "react-router-dom";
 import { convertLogicalIdentifier, LID_FORMAT } from "./strings";
 
-export type InvestigationDetailPathParams = {
+type InstrumentDetailPathParams = {
+  lid:string;
+}
+
+type InvestigationDetailPathParams = {
   lid:string;
 }
 
@@ -9,7 +13,12 @@ const generateLinkPath = (template:string, params:{[key:string]:string}) => {
   return generatePath(template, params)
 }
 
-export const getLinkToInvestigation = (params:InvestigationDetailPathParams) => {
+export const getLinkToInvestigationDetailPage = (params:InvestigationDetailPathParams) => {
   params.lid = convertLogicalIdentifier(params.lid,LID_FORMAT.URL_FRIENDLY);
   return generateLinkPath("/investigations/:lid/instruments", params);
+};
+
+export const getLinkToInstrumentDetailPage = (params:InstrumentDetailPathParams) => {
+  params.lid = convertLogicalIdentifier(params.lid,LID_FORMAT.URL_FRIENDLY);
+  return generateLinkPath("/instruments/:lid/data", params);
 };

--- a/apps/frontend/src/utils/links.ts
+++ b/apps/frontend/src/utils/links.ts
@@ -1,0 +1,15 @@
+import { generatePath } from "react-router-dom";
+import { convertLogicalIdentifier, LID_FORMAT } from "./strings";
+
+export type InvestigationDetailPathParams = {
+  lid:string;
+}
+
+const generateLinkPath = (template:string, params:{[key:string]:string}) => {
+  return generatePath(template, params)
+}
+
+export const getLinkToInvestigation = (params:InvestigationDetailPathParams) => {
+  params.lid = convertLogicalIdentifier(params.lid,LID_FORMAT.URL_FRIENDLY);
+  return generateLinkPath("/investigations/:lid/instruments", params);
+};


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

This PR addresses the following:

* Updated the investigation title stats item on the instrument detail page in the header so that it is now a link that can navigate a user to the respective investigation detail page
* Added new "links" utility to centralize the location of functions to assist with generating links throughout the portal.
* Updated investigation and instrument directory pages to use newly added link utility functions
* Removed unneeded code and import statements due to addition of links utility functions.

## ⚙️ Test Data and/or Report

Tested locally and ensured that `npm run build` does not generate any errors.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fixes #117 


