### PR TITLE
Add ability to maintian history of navigated pages when the search feature is used in the header.

### DIFF
--- a/apps/frontend/src/components/HomeSearch/HomeSearch.scss
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.scss
@@ -1,6 +1,7 @@
 .pds-home-search-container {
     background-color: var(--pds-secondary-blue-s1);
     color: var(--pds-primary-white);
+    text-align: left;
 }
 
 .pds-home-search-container-inner.MuiContainer-root{

--- a/apps/frontend/src/components/HomeSearch/HomeSearch.scss
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.scss
@@ -91,3 +91,7 @@
     text-transform: uppercase;
     text-wrap: auto;
 }
+
+.pds-home-search-chip.MuiButtonBase-root.MuiChip-root {
+    margin-right: 15px;
+}

--- a/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
@@ -825,6 +825,7 @@ export const HomeSearch = () => {
                 filter.value !== "all" ? (
                   <Chip
                     sx={{
+                      marginRight: "15px",
                       backgroundColor: "white",
                       textTransform: "uppercase",
                     }}

--- a/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
@@ -824,8 +824,8 @@ export const HomeSearch = () => {
               {selectedFilters.map((filter) =>
                 filter.value !== "all" ? (
                   <Chip
+                    className="pds-home-search-chip"
                     sx={{
-                      marginRight: "15px",
                       backgroundColor: "white",
                       textTransform: "uppercase",
                     }}

--- a/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
@@ -22,6 +22,7 @@ import {
   createSearchParams,
   generatePath,
   useNavigate,
+  useSearchParams,
 } from "react-router-dom";
 import {
   mapFilterIdsToName,
@@ -82,6 +83,8 @@ type SelectedFilter = {
 export const HomeSearch = () => {
   const searchInputRef = useRef("");
   const navigate = useNavigate();
+
+  const [searchParams] = useSearchParams();
 
   const [allTargetFilters, setAllTargetFilters] = useState<Filter[]>([]);
   const [allInvestigationFilters, setAllInvestigationFilters] = useState<
@@ -313,6 +316,27 @@ export const HomeSearch = () => {
     });
 
     setSelectedFilters(newSelectedFilters);
+
+    updateNavigate(searchInputRef.current, newSelectedFilters);
+  };
+
+  const updateNavigate = (searchText: string, filters: SelectedFilter[]) => {
+    const filtersString = filters.map((filter) => filter.value);
+
+    const queryParams = {
+      searchText,
+      filters: filtersString,
+    };
+
+    if (queryParams) {
+      navigate(
+        {
+          pathname: generatePath("/"),
+          search: createSearchParams(queryParams).toString(),
+        },
+        { replace: true }
+      );
+    }
   };
 
   const handleTargetFilterChange = (
@@ -371,6 +395,8 @@ export const HomeSearch = () => {
     event: ChangeEvent<HTMLInputElement>
   ) => {
     searchInputRef.current = event.target.value;
+
+    updateNavigate(searchInputRef.current, selectedFilters);
   };
 
   const formatSelectedFiltersForSearchPage = (filters: SelectedFilter[]) => {
@@ -484,6 +510,8 @@ export const HomeSearch = () => {
     }
 
     setSelectedFilters(newSelectedFilters);
+
+    updateNavigate(searchInputRef.current, newSelectedFilters);
   };
 
   const formatFilterDataResults = (data: SolrIdentifierNameResponse) => {
@@ -617,17 +645,6 @@ export const HomeSearch = () => {
                     );
                     pageTypeFilters.splice(0, 0, { name: "All", value: "all" });
 
-                    console.log(
-                      "investigationFilterOptions",
-                      investigationFilterOptions
-                    );
-                    console.log(
-                      "instrumentFilterOptions",
-                      instrumentFilterOptions
-                    );
-                    console.log("targetFilterOptions", targetFilterOptions);
-                    console.log("pageTypeFilterOptions", pageTypeFilterOptions);
-
                     setAllInvestigationFilters(investigationFilters);
                     setAllInstrumentFilters(instrumentFilters);
                     setAllTargetFilters(targetFilters);
@@ -637,6 +654,111 @@ export const HomeSearch = () => {
                     setInvestigationFilters(investigationFilters);
                     setInstrumentFilters(instrumentFilters);
                     setPageTypeFilters(pageTypeFilters);
+
+                    const filters = searchParams.getAll("filters");
+
+                    let preInvestigationFilters: {
+                      name: string;
+                      value: string;
+                    }[] = [];
+
+                    let preInstrumentFilters: {
+                      name: string;
+                      value: string;
+                    }[] = [];
+
+                    let preTargetFilters: {
+                      name: string;
+                      value: string;
+                    }[] = [];
+
+                    let preTypeFilters: {
+                      name: string;
+                      value: string;
+                    }[] = [];
+
+                    filters.forEach((filterId) => {
+                      preInvestigationFilters = preInvestigationFilters.concat(
+                        investigationFilters.filter(
+                          (investigation) => investigation.value === filterId
+                        )
+                      );
+                      preInstrumentFilters = preInstrumentFilters.concat(
+                        instrumentFilters.filter(
+                          (instrument) => instrument.value === filterId
+                        )
+                      );
+                      preTargetFilters = preTargetFilters.concat(
+                        targetFilters.filter(
+                          (target) => target.value === filterId
+                        )
+                      );
+                      preTypeFilters = preTypeFilters.concat(
+                        pageTypeFilters.filter(
+                          (pageType) => pageType.value === filterId
+                        )
+                      );
+                    });
+
+                    const mergedFilters: SelectedFilter[] = [];
+                    if (preInvestigationFilters.length > 0) {
+                      setSelectedInvestigationFilters(
+                        preInvestigationFilters.map((filter) => filter.value)
+                      );
+
+                      preInvestigationFilters.forEach((filter) => {
+                        const newFilter: SelectedFilter = {
+                          name: filter.name,
+                          value: filter.value,
+                          parentFilterName: "investigations",
+                        };
+                        mergedFilters.push(newFilter);
+                      });
+                    }
+                    if (preInstrumentFilters.length > 0) {
+                      setSelectedInstrumentFilters(
+                        preInstrumentFilters.map((filter) => filter.value)
+                      );
+
+                      preInstrumentFilters.forEach((filter) => {
+                        const newFilter: SelectedFilter = {
+                          name: filter.name,
+                          value: filter.value,
+                          parentFilterName: "instruments",
+                        };
+                        mergedFilters.push(newFilter);
+                      });
+                    }
+                    if (preTargetFilters.length > 0) {
+                      setSelectedTargetFilters(
+                        preTargetFilters.map((filter) => filter.value)
+                      );
+
+                      preTargetFilters.forEach((filter) => {
+                        const newFilter: SelectedFilter = {
+                          name: filter.name,
+                          value: filter.value,
+                          parentFilterName: "targets",
+                        };
+                        mergedFilters.push(newFilter);
+                      });
+                    }
+                    if (preTypeFilters.length > 0) {
+                      setSelectedPageTypeFilters(
+                        preTypeFilters.map((filter) => filter.value)
+                      );
+
+                      preTypeFilters.forEach((filter) => {
+                        const newFilter: SelectedFilter = {
+                          name: filter.name,
+                          value: filter.value,
+                          parentFilterName: "page_type",
+                        };
+                        mergedFilters.push(newFilter);
+                      });
+                    }
+
+                    setSelectedFilters(mergedFilters);
                   });
               });
           });
@@ -687,7 +809,7 @@ export const HomeSearch = () => {
                 onChange={handleSearchInputValueChange}
                 onKeyDown={handleKeyDown}
                 inputRef={searchInputRef}
-                defaultValue=""
+                defaultValue={searchParams.get("searchText")}
               />
               <Button
                 variant={"cta"}


### PR DESCRIPTION
## 🗒️ Summary
Search text in the search bar and the selected filters are kept in the URL history. Once a new page is opened the back button will reload the changes. A link can also be saved to be reopened later.

Updated some minor css on the home page search.

## ⚙️ Test Data and/or Report
Run with https://github.com/NASA-PDS/wds-react/pull/79. Test the home page by making some selections or typing something in the search box. Click on search or click on a link. Press the back button. The page will load as it was before.

## ♻️ Related Issues
fixes #97 
references https://github.com/NASA-PDS/wds-react/pull/79
