### PR TITLE
Add Solr String To String Array Flexibility #137

### DIFF
--- a/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
@@ -27,6 +27,7 @@ import {
 import {
   mapFilterIdsToName,
   mapPageType,
+  formatIdentifierNameResults,
 } from "../../pages/search/searchUtils";
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
@@ -588,11 +589,13 @@ export const HomeSearch = () => {
                     }
 
                     const investigationNames: IdentifierNameDoc[] =
-                      investigationsData.response.docs;
+                      formatIdentifierNameResults(investigationsData).response
+                        .docs;
                     const instrumentNames: IdentifierNameDoc[] =
-                      instrumentsData.response.docs;
+                      formatIdentifierNameResults(instrumentsData).response
+                        .docs;
                     const targetNames: IdentifierNameDoc[] =
-                      targetsData.response.docs;
+                      formatIdentifierNameResults(targetsData).response.docs;
 
                     const investigationFilterOptions = mapFilterIdsToName(
                       investigationFilterIds,

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -1576,10 +1576,9 @@ const SearchPage = () => {
                                         : "/",
                                     }}
                                     investigation={
-                                      doc["form-instrument-host"]
+                                      doc.instrument_host_name
                                         ? {
-                                            value:
-                                              doc["form-instrument-host"][0],
+                                            value: doc.instrument_host_name[0],
                                           }
                                         : { value: "-" }
                                     }

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -1246,7 +1246,7 @@ const SearchPage = () => {
                             <Box>
                               {getDocType(doc) === "databundle" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1332,7 +1332,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "datacollection" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1420,7 +1420,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "dataset" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1492,7 +1492,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "facility" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.facility_description
                                       ? doc.facility_description[0]
@@ -1542,7 +1542,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "instrument" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.instrument_description
                                       ? doc.instrument_description[0]
@@ -1591,7 +1591,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "instrument_host" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.instrument_host_description
                                       ? doc.instrument_host_description[0]
@@ -1659,7 +1659,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "investigation" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.investigation_description
                                       ? doc.investigation_description[0]
@@ -1730,7 +1730,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "resource" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1767,7 +1767,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "target" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1805,7 +1805,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "telescope" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.telescope_description
                                       ? doc.telescope_description[0]
@@ -1850,7 +1850,7 @@ const SearchPage = () => {
 
                               {getDocType(doc) === "tool" ? (
                                 <FeaturedLink
-                                  title={doc.title ? doc.title : "-"}
+                                  title={doc.title ? doc.title[0] : "-"}
                                   description={
                                     doc.description ? doc.description[0] : "-"
                                   }
@@ -1870,7 +1870,7 @@ const SearchPage = () => {
                                   <FeaturedLinkDetails
                                     support={
                                       doc.pds_model_version
-                                        ? { value: doc.pds_model_version }
+                                        ? { value: doc.pds_model_version[0] }
                                         : { value: "-" }
                                     }
                                     url={

--- a/apps/frontend/src/pages/search/searchUtils.ts
+++ b/apps/frontend/src/pages/search/searchUtils.ts
@@ -1,9 +1,20 @@
 import {
     IdentifierNameDoc,
+    IdentifierNameResponse,
+    Response,
     SolrSearchResponse,
     SolrIdentifierNameResponse,
     SearchResultDoc,
 } from "src/types/solrSearchResponse";
+
+import {
+    SolrSearchResponse as SolrSearchResponseExpected,
+    SolrIdentifierNameResponse as SolrIdentifierNameResponseExpected,
+    IdentifierNameResponse as IdentifierNameResponseExpected,
+    IdentifierNameDoc as IdentifierNameDocExpected,
+    Response as ResponseExpected,
+    SearchResultDoc as SearchResultDocExpected
+} from "src/types/solrSearchResponseExpected";
 
 export const calculatePaginationCount = (data: SolrSearchResponse) => {
     const rows = Number(data.responseHeader.params.rows);
@@ -80,14 +91,6 @@ export const formatFilterQueries = (filters: string) => {
     });
 
     return formattedFilterQueryString;
-};
-
-export const formatIdentifierNameResults = (data: SolrIdentifierNameResponse) => {
-    return data;
-};
-
-export const formatSearchResults = (data: SolrSearchResponse) => {
-    return data;
 };
 
 export const getDocType = (doc: SearchResultDoc) => {
@@ -227,7 +230,7 @@ const getUnmatchedFilterName = (
     }
 
     for(let i = 0; i < originals.length; i++){
-        if(originals[i].identifier === identifier){
+        if(originals[i].identifier[0] === identifier){
             if(parentName === "target_ref"){
                 return originals[i].target_name[0];
             }
@@ -306,7 +309,7 @@ export const mapFilterIdsToName = (ids: string[], names: IdentifierNameDoc[], se
           let name: string = "";
 
           if (nameDoc.title) {
-            name = nameDoc.title;
+            name = nameDoc.title[0];
           }
 
           filtersMap.push({
@@ -353,3 +356,196 @@ export const mapPageType = (ids: string[], searchResultFacets?: (number | string
 
     return filtersMap;
 };
+
+export const formatSearchResults = (data: SolrSearchResponseExpected) => {
+    const formattedData: SolrSearchResponse = transformSolrSearchResponseExpected(data);
+
+    return formattedData;
+};
+
+
+const transformSolrSearchResponseExpected = (data: SolrSearchResponseExpected) => {
+    const formattedData: SolrSearchResponse  = {
+        response: transformResponse(data.response),
+        responseHeader: data.responseHeader,
+        facet_counts: data.facet_counts
+    }
+
+    return formattedData;
+};
+
+
+const transformResponse = (data: ResponseExpected) => {
+    const formattedData: Response  = {
+        numFound: data.numFound,
+        start: data.start,
+        maxScore: data.maxScore,
+        docs: transformDocs(data.docs)
+    }
+
+    return formattedData;
+}
+
+const transformDocs = (data: SearchResultDocExpected[]) => {
+    const formattedData: SearchResultDoc[] = [];
+
+    data.forEach((docExpected) => {
+        const doc: SearchResultDoc = {
+            file_ref_location: convertToStringArray(docExpected.file_ref_location),
+            data_class:convertToStringArray(docExpected.data_class),
+            description: convertToStringArray(docExpected.description),
+            file_ref_url: convertToStringArray(docExpected.file_ref_url),
+            title: convertToStringArray(docExpected.title),
+            resLocation: convertToStringArray(docExpected.resLocation),
+            objectType: convertToStringArray(docExpected.objectType),
+            product_class: convertToStringArray(docExpected.product_class),
+            data_product_type: convertToStringArray(docExpected.data_product_type),
+            file_ref_size: convertToStringArray(docExpected.file_ref_size),
+            modification_date: convertToStringArray(docExpected.modification_date),
+            file_ref_name: convertToStringArray(docExpected.file_ref_name),
+            identifier: convertToStringArray(docExpected.identifier),
+            resource_url: convertToStringArray(docExpected.resource_url),
+            agency_name: convertToStringArray(docExpected.agency_name),
+            'form-agency': convertToStringArray(docExpected['form-agency']),
+            modification_description: convertToStringArray(docExpected.modification_description),
+            resource_type: convertToStringArray(docExpected.resource_type),
+            search_id: convertToStringArray(docExpected.search_id),
+            pds_model_version: convertToStringArray(docExpected.pds_model_version),
+            resource_description: convertToStringArray(docExpected.resource_description),
+            resource_name: convertToStringArray(docExpected.resource_name),
+            timestamp: convertToStringArray(docExpected.timestamp),
+            score: docExpected.score,
+            investigation_type: convertToStringArray(docExpected.investigation_type),
+            primary_result_purpose: convertToStringArray(docExpected.primary_result_purpose),
+            node_id: convertToStringArray(docExpected.node_id),
+            instrument_type: convertToStringArray(docExpected.instrument_type),
+            facility_country: convertToStringArray(docExpected.facility_country),
+            facility_type: convertToStringArray(docExpected.facility_type),
+            facility_description: convertToStringArray(docExpected.facility_description),
+            telescope_description: convertToStringArray(docExpected.telescope_description),
+            telescope_aperture: convertToStringArray(docExpected.telescope_aperture),
+            instrument_name: convertToStringArray(docExpected.instrument_name),
+            investigation_ref: convertToStringArray(docExpected.investigation_ref),
+            citation_publication_year: convertToStringArray(docExpected.citation_publication_year) 
+        }
+
+        if(docExpected.collection_type){
+            doc.collection_type = convertToStringArray(docExpected.collection_type);
+        }
+        if(docExpected.investigation_description){
+            doc.investigation_description = convertToStringArray(docExpected.investigation_description);
+        }
+        if(docExpected.instrument_host_name){
+            doc.instrument_host_name = convertToStringArray(docExpected.instrument_host_name);
+        }
+        if(docExpected.investigation_start_date){
+            doc.investigation_start_date = convertToStringArray(docExpected.investigation_start_date);
+        }
+        if(docExpected.investigation_stop_date){
+            doc.investigation_stop_date = convertToStringArray(docExpected.investigation_stop_date);
+        }
+        if(docExpected.instrument_description){
+            doc.instrument_description = convertToStringArray(docExpected.instrument_description);
+        }
+        if(docExpected['form-instrument-type']){
+            doc['form-instrument-type'] = convertToStringArray(docExpected['form-instrument-type']);
+        }
+        if(docExpected['form-instrument-host']){
+            doc['form-instrument-host'] = convertToStringArray(docExpected['form-instrument-host']);
+        }
+        if(docExpected['form-investigation']){
+            doc['form-investigation'] = convertToStringArray(docExpected['form-investigation']);
+        }
+        if(docExpected.citation_doi){
+            doc.citation_doi = convertToStringArray(docExpected.citation_doi);
+        }
+        if(docExpected.primary_result_processing_level){
+            doc.primary_result_processing_level = convertToStringArray(docExpected.primary_result_processing_level);
+        }
+        if(docExpected.observation_start_date_time){
+            doc.observation_start_date_time = convertToStringArray(docExpected.observation_start_date_time);
+        }
+        if(docExpected.observation_stop_date_time){
+            doc.observation_stop_date_time = convertToStringArray(docExpected.observation_stop_date_time);
+        }
+        if(docExpected.investigation_name){
+            doc.investigation_name = convertToStringArray(docExpected.investigation_name);
+        }
+        if(docExpected.primary_result_discipline_name){
+            doc.primary_result_discipline_name = convertToStringArray(docExpected.primary_result_discipline_name);
+        }
+        if(docExpected.target_type){
+            doc.target_type = convertToStringArray(docExpected.target_type);
+        }
+        if(docExpected.service_url){
+            doc.service_url = convertToStringArray(docExpected.service_url);
+        }
+        if(docExpected.version_id){
+            doc.version_id = convertToStringArray(docExpected.version_id);
+        }
+        if(docExpected.service_category){
+            doc.service_category = convertToStringArray(docExpected.service_category);
+        }
+        if(docExpected['form-target']){
+            doc['form-target'] = convertToStringArray(docExpected['form-target']);
+        }
+        if(docExpected.target_description){
+            doc.target_description = convertToStringArray(docExpected.target_description);
+        }
+        if(docExpected.instrument_host_description){
+            doc.instrument_host_description = convertToStringArray(docExpected.instrument_host_description);
+        }
+
+        formattedData.push(doc);
+    });
+
+    return formattedData;
+}
+
+export const formatIdentifierNameResults = (data: SolrIdentifierNameResponseExpected) => {
+    const formattedData: SolrIdentifierNameResponse = transformSolrIdentifierNameResponse(data);
+
+    return formattedData;
+};
+
+
+const transformSolrIdentifierNameResponse = (data: SolrIdentifierNameResponseExpected) => {
+    const formattedData: SolrIdentifierNameResponse  = {
+        response: transformIdentifierNameResponse(data.response),
+        responseHeader: data.responseHeader,
+        facet_counts: data.facet_counts
+    }
+
+    return formattedData;
+}
+
+const transformIdentifierNameResponse = (data: IdentifierNameResponseExpected) => {
+    const formattedData: IdentifierNameResponse  = {
+        numFound: data.numFound,
+        start: data.start,
+        maxScore: data.maxScore,
+        docs: transformIdentifierNameDocs(data.docs)
+    }
+
+    return formattedData;
+}
+
+const transformIdentifierNameDocs = (data: IdentifierNameDocExpected[]) => {
+    const formattedData: IdentifierNameDoc[] = [];
+
+    data.forEach((docExpected) => {
+        const doc = {
+            identifier: convertToStringArray(docExpected.identifier),
+            investigation_name: convertToStringArray(docExpected.investigation_name),
+            instrument_name: convertToStringArray(docExpected.instrument_name),
+            target_name: convertToStringArray(docExpected.target_name),
+            title: convertToStringArray(docExpected.title),
+        }
+
+        formattedData.push(doc);
+    });
+
+    return formattedData;
+}
+
+const convertToStringArray = (param: string | string[]): string[] => Array.isArray(param) ? param : [param];

--- a/apps/frontend/src/pages/search/searchUtils.ts
+++ b/apps/frontend/src/pages/search/searchUtils.ts
@@ -447,14 +447,8 @@ const transformDocs = (data: SearchResultDocExpected[]) => {
         if(docExpected.instrument_description){
             doc.instrument_description = convertToStringArray(docExpected.instrument_description);
         }
-        if(docExpected['form-instrument-type']){
-            doc['form-instrument-type'] = convertToStringArray(docExpected['form-instrument-type']);
-        }
         if(docExpected['form-instrument-host']){
             doc['form-instrument-host'] = convertToStringArray(docExpected['form-instrument-host']);
-        }
-        if(docExpected['form-investigation']){
-            doc['form-investigation'] = convertToStringArray(docExpected['form-investigation']);
         }
         if(docExpected.citation_doi){
             doc.citation_doi = convertToStringArray(docExpected.citation_doi);

--- a/apps/frontend/src/types/solrSearchResponse.d.ts
+++ b/apps/frontend/src/types/solrSearchResponse.d.ts
@@ -26,7 +26,6 @@ export type Facetfields = {
     facet_instrument: (number | string)[];
     facet_primary_result_purpose: (number | string)[];
     facet_primary_result_processing_level: string[];
-
     page_type: string[];
     investigation_ref: string[];
     target_ref: string[];
@@ -35,7 +34,7 @@ export type Facetfields = {
 
 type Facetqueries = object;
 
-type Response = {
+export type Response = {
     numFound: number;
     start: number;
     maxScore: number;
@@ -54,26 +53,26 @@ type SearchResultDoc = {
     data_class: string[];
     description: string[];
     file_ref_url: string[];
-    title: string;
-    resLocation: string;
-    objectType: string;
+    title: string[];
+    resLocation: string[];
+    objectType: string[];
     product_class: string[];
     data_product_type: string[];
     file_ref_size: string[];
     modification_date: string[];
     file_ref_name: string[];
-    identifier: string;
+    identifier: string[];
     resource_url: string[];
     agency_name: string[];
     'form-agency': string[];
     modification_description: string[];
     resource_type: string[];
     version_id: string[];
-    search_id: string;
-    pds_model_version: string;
+    search_id: string[];
+    pds_model_version: string[];
     resource_description: string[];
     resource_name: string[];
-    timestamp: string;
+    timestamp: string[];
     score: number;
     collection_type?: string[];
     investigation_description?: string[];
@@ -114,11 +113,11 @@ type SearchResultDoc = {
 }
 
 type IdentifierNameDoc = {
-    identifier: string;
+    identifier: string[];
     investigation_name: string[];
     instrument_name: string[];
     target_name: string[];
-    title: string;
+    title: string[];
 }
 
 type ResponseHeader = {

--- a/apps/frontend/src/types/solrSearchResponse.d.ts
+++ b/apps/frontend/src/types/solrSearchResponse.d.ts
@@ -80,9 +80,7 @@ type SearchResultDoc = {
     investigation_start_date?: string[];
     investigation_stop_date?: string[];
     instrument_description?: string[];
-    'form-instrument-type'?: string[];
     'form-instrument-host'?: string[];
-    'form-investigation'?: string[];
     citation_doi?: string[];
     primary_result_processing_level?: string[];
     observation_start_date_time?: string[];

--- a/apps/frontend/src/types/solrSearchResponseExpected.d.ts
+++ b/apps/frontend/src/types/solrSearchResponseExpected.d.ts
@@ -79,9 +79,7 @@ export type SearchResultDoc = {
     investigation_start_date?: string | string[];
     investigation_stop_date?: string | string[];
     instrument_description?: string | string[];
-    'form-instrument-type'?: string | string[];
     'form-instrument-host'?: string | string[];
-    'form-investigation'?: string | string[];
     citation_doi?: string | string[];
     primary_result_processing_level?: string | string[];
     observation_start_date_time?: string | string[];

--- a/apps/frontend/src/types/solrSearchResponseExpected.d.ts
+++ b/apps/frontend/src/types/solrSearchResponseExpected.d.ts
@@ -1,0 +1,132 @@
+export type SolrSearchResponse = {
+    responseHeader: ResponseHeader;
+    response: Response;
+    facet_counts: Facetcounts;
+}
+
+export type SolrIdentifierNameResponse = {
+    responseHeader: ResponseHeader;
+    response: IdentifierNameResponse;
+    facet_counts: Facetcounts;
+}
+
+export type Facetcounts = {
+    facet_queries: Facetqueries;
+    facet_fields: Facetfields;
+    facet_dates: Facetqueries;
+    facet_ranges: Facetqueries;
+}
+
+export type Facetfields = {
+    facet_pds_model_version: (number | string)[];
+    facet_agency: (number | string)[];
+    facet_type: (number | string)[];
+    facet_target: (number | string)[];
+    facet_investigation: (number | string)[];
+    facet_instrument: (number | string)[];
+    facet_primary_result_purpose: (number | string)[];
+    facet_primary_result_processing_level: string[];
+    page_type: string[];
+    investigation_ref: string[];
+    target_ref: string[];
+    instrument_ref: string[];
+}
+
+type Facetqueries = object;
+
+export type Response = {
+    numFound: number;
+    start: number;
+    maxScore: number;
+    docs: SearchResultDoc[];
+}
+
+type IdentifierNameResponse = {
+    numFound: number;
+    start: number;
+    maxScore: number;
+    docs: IdentifierNameDoc[];
+}
+
+export type SearchResultDoc = {
+    file_ref_location: string | string[];
+    data_class: string | string[];
+    description: string | string[];
+    file_ref_url: string | string[];
+    title: string | string[];
+    resLocation: string | string[];
+    objectType: string | string[];
+    product_class: string | string[];
+    data_product_type: string | string[];
+    file_ref_size: string | string[];
+    modification_date: string | string[];
+    file_ref_name: string | string[];
+    identifier: string | string[];
+    resource_url: string | string[];
+    agency_name: string | string[];
+    'form-agency': string | string[];
+    modification_description: string | string[];
+    resource_type: string | string[];
+    search_id: string | string[];
+    pds_model_version: string | string[];
+    resource_description: string | string[];
+    resource_name: string | string[];
+    timestamp: string | string[];
+    score: number;
+    collection_type?: string | string[];
+    investigation_description?: string | string[];
+    instrument_host_name?: string | string[];
+    investigation_start_date?: string | string[];
+    investigation_stop_date?: string | string[];
+    instrument_description?: string | string[];
+    'form-instrument-type'?: string | string[];
+    'form-instrument-host'?: string | string[];
+    'form-investigation'?: string | string[];
+    citation_doi?: string | string[];
+    primary_result_processing_level?: string | string[];
+    observation_start_date_time?: string | string[];
+    observation_stop_date_time?: string | string[];
+    investigation_name?: string | string[];
+    primary_result_discipline_name?: string | string[];
+    target_type?: string | string[];
+    service_url?: string | string[];
+    version_id?: string | string[];
+    service_category?: string | string[];
+    'form-target'?: string | string[];
+    target_description?: string | string[];
+    instrument_host_description?: string | string[];
+    investigation_type: string | string[];
+    primary_result_purpose: string | string[];
+    node_id: string | string[];
+    instrument_type: string | string[];
+    facility_country: string | string[];
+    facility_type: string | string[];
+    facility_description: string | string[];
+    telescope_description: string | string[];
+    telescope_aperture: string | string[];
+    instrument_name: string | string[];
+    investigation_ref: string | string[];
+    citation_publication_year: string | string[];
+}
+
+type IdentifierNameDoc = {
+    identifier: string | string[];
+    investigation_name: string | string[];
+    instrument_name: string | string[];
+    target_name: string | string[];
+    title: string | string[];
+}
+
+type ResponseHeader = {
+    status: number;
+    QTime: number;
+    params: Params;
+}
+
+type Params = {
+    q: string;
+    start: string;
+    fq: string[] | string;
+    rows: string;
+    wt: string;
+}


### PR DESCRIPTION
## 🗒️ Summary
As solr is being developed some types change between strings or string arrays. This pull request adds an expected type that the client will expect from solr. It will then convert all values to arrays and use that type instead. This way it won't break the client due to unexpected type if solr types suddenly change.


## ⚙️ Test Data and/or Report
Run normally. All values will look the same. Tested build process is successful.

## ♻️ Related Issues
fixes #137 


