### PR TITLE
Remove Checkbox From Single Select Filters #141

### DIFF
--- a/apps/frontend/src/components/Filters/Filter.tsx
+++ b/apps/frontend/src/components/Filters/Filter.tsx
@@ -170,11 +170,7 @@ const Filter = ({
                           name={option.value}
                           value={value}
                           checked={option.isChecked}
-                          disabled={
-                            option.isChecked && option.title === "all"
-                              ? true
-                              : false
-                          }
+                          disabled={option.isChecked && option.title === "all"}
                         />
                         <Typography variant="h6" weight="regular">
                           {option.title.toUpperCase()}

--- a/apps/frontend/src/components/Filters/Filter.tsx
+++ b/apps/frontend/src/components/Filters/Filter.tsx
@@ -30,7 +30,7 @@ export type FilterProps = {
   title: string;
   options: FilterOptionProps[];
   onChecked: (event: ChangeEvent<HTMLInputElement>) => void;
-  onCheckedRadio: (event: ChangeEvent<HTMLInputElement>) => void;
+  onCheckedRadio: (name: string, checked: boolean, value: string) => void;
   collapseAll?: boolean;
   variant: FilterVariant;
 };
@@ -72,102 +72,158 @@ const Filter = ({
     return isIncluded;
   };
 
+  const isASingleSelected = (
+    possibleOptions: FilterOptionProps[],
+    filterVariant: FilterVariant
+  ) => {
+    let isSingleAndSelected = false;
+    if (filterVariant === "single") {
+      possibleOptions.forEach((option) => {
+        if (option.value !== "all" && option.isChecked === true) {
+          isSingleAndSelected = true;
+        }
+      });
+    }
+
+    return isSingleAndSelected;
+  };
+
   useEffect(() => {
     setIsCollapsed(collapseAll);
   }, [collapseAll]);
 
   return (
-    <div>
-      <Box>
-        <Grid
-          container
-          spacing={2}
-          alignItems="center"
-          sx={{ paddingBottom: 0 }}
-        >
-          <Grid item xs={10}>
-            <Typography variant="h8" weight="semibold">
-              {displayTitle.toUpperCase()}
-            </Typography>
-          </Grid>
-          <Grid item xs={2} className="pds-search-filter-dropdown-button-grid">
-            <IconButton aria-label="star" onClick={handleCollapseClick}>
-              {isCollapsed ? <IconArrowCircleDown /> : <IconArrowCircleUp />}
-            </IconButton>
-          </Grid>
-        </Grid>
-      </Box>
+    <>
+      {!isASingleSelected(options, variant) ? (
+        <div>
+          <Box>
+            <Grid
+              container
+              spacing={2}
+              alignItems="center"
+              sx={{ paddingBottom: 0 }}
+            >
+              <Grid item xs={10}>
+                <Typography variant="h8" weight="semibold">
+                  {displayTitle.toUpperCase()}
+                </Typography>
+              </Grid>
+              <Grid
+                item
+                xs={2}
+                className="pds-search-filter-dropdown-button-grid"
+              >
+                <IconButton aria-label="star" onClick={handleCollapseClick}>
+                  {isCollapsed ? (
+                    <IconArrowCircleDown />
+                  ) : (
+                    <IconArrowCircleUp />
+                  )}
+                </IconButton>
+              </Grid>
+            </Grid>
+          </Box>
+          {!isCollapsed ? (
+            <Grid
+              container
+              spacing={2}
+              alignItems="center"
+              sx={{ paddingBottom: 0 }}
+            >
+              <Grid item xs={12}>
+                <TextField
+                  className="pds-filter-textfield"
+                  id="subfilter"
+                  value={subFilter}
+                  variant="standard"
+                  onChange={onSubFilterChange}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <IconSearch />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+              </Grid>
+            </Grid>
+          ) : (
+            <></>
+          )}
+          {!isCollapsed ? (
+            <Box className="pds-search-filter-checkbox-container">
+              {options.map((option) =>
+                titleIncludesSubFilter(option.title, subFilter) ? (
+                  <Box
+                    className="pds-search-filter-checkbox-box"
+                    sx={{
+                      cursor: "pointer",
+                      display: "flex",
+                      alignItems: "start",
+                    }}
+                  >
+                    {variant !== "single" ? (
+                      <>
+                        <Checkbox
+                          sx={{ padding: 0 }}
+                          onChange={onChecked}
+                          name={option.value}
+                          value={value}
+                          checked={option.isChecked}
+                          disabled={
+                            option.isChecked && option.title === "all"
+                              ? true
+                              : false
+                          }
+                        />
+                        <Typography variant="h6" weight="regular">
+                          {option.title.toUpperCase()}
 
-      {!isCollapsed ? (
-        <Grid
-          container
-          spacing={2}
-          alignItems="center"
-          sx={{ paddingBottom: 0 }}
-        >
-          <Grid item xs={12}>
-            <TextField
-              className="pds-filter-textfield"
-              id="subfilter"
-              value={subFilter}
-              variant="standard"
-              onChange={onSubFilterChange}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <IconSearch />
-                  </InputAdornment>
-                ),
-              }}
-            />
-          </Grid>
-        </Grid>
+                          <span className="pds-search-filter-count-span">
+                            {option.title === "all"
+                              ? ""
+                              : " (" + option.resultsFound + ")"}
+                          </span>
+                        </Typography>
+                      </>
+                    ) : (
+                      <div>
+                        <Typography
+                          variant="h6"
+                          weight="regular"
+                          onClick={() =>
+                            onCheckedRadio(
+                              option.value,
+                              !option.isChecked,
+                              value
+                            )
+                          }
+                        >
+                          {option.title.toUpperCase()}
+
+                          <span className="pds-search-filter-count-span">
+                            {option.title === "all"
+                              ? ""
+                              : " (" + option.resultsFound + ")"}
+                          </span>
+                        </Typography>
+                      </div>
+                    )}
+                  </Box>
+                ) : (
+                  <></>
+                )
+              )}
+            </Box>
+          ) : (
+            ""
+          )}
+          <Divider />
+        </div>
       ) : (
         <></>
       )}
-
-      {!isCollapsed ? (
-        <Box className="pds-search-filter-checkbox-container">
-          {options.map((option) =>
-            titleIncludesSubFilter(option.title, subFilter) ? (
-              <Box
-                className="pds-search-filter-checkbox-box"
-                sx={{
-                  cursor: "pointer",
-                  display: "flex",
-                  alignItems: "start",
-                }}
-              >
-                <Checkbox
-                  sx={{ padding: 0 }}
-                  onChange={variant === "single" ? onCheckedRadio : onChecked}
-                  name={option.value}
-                  value={value}
-                  checked={option.isChecked}
-                  disabled={
-                    option.isChecked && option.title === "all" ? true : false
-                  }
-                />
-                <Typography variant="h6" weight="regular">
-                  {option.title.toUpperCase()}
-
-                  <span className="pds-search-filter-count-span">
-                    {option.title === "all"
-                      ? ""
-                      : " (" + option.resultsFound + ")"}
-                  </span>
-                </Typography>
-              </Box>
-            ) : (
-              <></>
-            )
-          )}
-        </Box>
-      ) : (
-        ""
-      )}
-      <Divider />
-    </div>
+    </>
   );
 };
 

--- a/apps/frontend/src/components/Filters/Filters.tsx
+++ b/apps/frontend/src/components/Filters/Filters.tsx
@@ -7,7 +7,7 @@ import { Chip, Typography } from "@nasapds/wds-react";
 export type FiltersProps = {
   filters: FilterProps[];
   onChecked: (event: ChangeEvent<HTMLInputElement>) => void;
-  onCheckedRadio: (event: ChangeEvent<HTMLInputElement>) => void;
+  onCheckedRadio: (name: string, checked: boolean, value: string) => void;
   onFilterChipDelete: (value: string, parentValue: string) => void;
   onFilterClear: () => void;
   collapseAll?: boolean;
@@ -41,7 +41,7 @@ const Filters = ({
         filter.options.forEach((option) => {
           if (option.value !== "all" && option.isChecked) {
             const optionProps = {
-              title: option.title,
+              title: filter.displayTitle + " : " + option.title,
               value: option.value,
               resultsFound: option.resultsFound,
               isChecked: option.isChecked,

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -1270,7 +1270,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1358,7 +1358,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1444,7 +1444,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1507,10 +1507,10 @@ const SearchPage = () => {
                                   description={
                                     doc.facility_description
                                       ? getFacilityDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.facility_description[0]
                                         )
-                                      : getFacilityDescription(doc.title, "")
+                                      : getFacilityDescription(doc.title[0], "")
                                   }
                                   primaryLink={
                                     doc.identifier
@@ -1521,7 +1521,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1560,15 +1560,18 @@ const SearchPage = () => {
                                   description={
                                     doc.instrument_description
                                       ? getInstrumentDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.instrument_description[0]
                                         )
                                       : doc.description
                                       ? getInstrumentDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.description[0]
                                         )
-                                      : getInstrumentDescription(doc.title, "")
+                                      : getInstrumentDescription(
+                                          doc.title[0],
+                                          ""
+                                        )
                                   }
                                   primaryLink={
                                     doc.identifier
@@ -1579,7 +1582,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1614,16 +1617,16 @@ const SearchPage = () => {
                                   description={
                                     doc.instrument_host_description
                                       ? getInstrumentHostDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.instrument_host_description[0]
                                         )
                                       : doc.description
                                       ? getInstrumentHostDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.description[0]
                                         )
                                       : getInstrumentHostDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           ""
                                         )
                                   }
@@ -1640,7 +1643,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1691,18 +1694,18 @@ const SearchPage = () => {
                                   description={
                                     doc.investigation_description
                                       ? getInvestigationDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.investigation_description[0]
                                         )
                                       : doc.instrument_host_description
                                       ? doc.instrument_host_description[0]
                                       : doc.description
                                       ? getInvestigationDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.description[0]
                                         )
                                       : getInvestigationDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           ""
                                         )
                                   }
@@ -1715,7 +1718,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1780,7 +1783,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1808,7 +1811,7 @@ const SearchPage = () => {
                                   description={
                                     doc.description
                                       ? getTargetDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.description[0]
                                         )
                                       : "-"
@@ -1822,7 +1825,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1851,10 +1854,13 @@ const SearchPage = () => {
                                   description={
                                     doc.telescope_description
                                       ? getTelescopeDescription(
-                                          doc.title,
+                                          doc.title[0],
                                           doc.telescope_description[0]
                                         )
-                                      : getTelescopeDescription(doc.title, "")
+                                      : getTelescopeDescription(
+                                          doc.title[0],
+                                          ""
+                                        )
                                   }
                                   primaryLink={
                                     doc.identifier
@@ -1865,7 +1871,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },
@@ -1906,7 +1912,7 @@ const SearchPage = () => {
                                   columns={[
                                     {
                                       horizontalAlign: "center",
-                                      data: doc.page_type,
+                                      data: doc.page_type[0],
                                       verticalAlign: "center",
                                       width: 1,
                                     },

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -14,7 +14,15 @@ import {
   FilterProps,
   FilterVariant,
 } from "../../components/Filters/Filter";
-import { ellipsisText, getFacilityDescription, getInstrumentDescription, getInstrumentHostDescription, getInvestigationDescription, getTargetDescription, getTelescopeDescription } from "../../utils/strings";
+import {
+  ellipsisText,
+  getFacilityDescription,
+  getInstrumentDescription,
+  getInstrumentHostDescription,
+  getInvestigationDescription,
+  getTargetDescription,
+  getTelescopeDescription,
+} from "../../utils/strings";
 import {
   getLinkToInstrumentDetailPage,
   getLinkToInvestigationDetailPage,
@@ -660,8 +668,11 @@ const SearchPage = () => {
     );
   };
 
-  const handleFilterCheckedRadio = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, checked, value } = e.target;
+  const handleFilterCheckedRadio = (
+    name: string,
+    checked: boolean,
+    value: string
+  ) => {
     let filters = "";
 
     if (name === "all") {
@@ -1495,7 +1506,10 @@ const SearchPage = () => {
                                   title={doc.title ? doc.title : "-"}
                                   description={
                                     doc.facility_description
-                                      ? getFacilityDescription(doc.title, doc.facility_description[0])
+                                      ? getFacilityDescription(
+                                          doc.title,
+                                          doc.facility_description[0]
+                                        )
                                       : getFacilityDescription(doc.title, "")
                                   }
                                   primaryLink={
@@ -1545,9 +1559,15 @@ const SearchPage = () => {
                                   title={doc.title ? doc.title : "-"}
                                   description={
                                     doc.instrument_description
-                                      ? getInstrumentDescription(doc.title, doc.instrument_description[0])
+                                      ? getInstrumentDescription(
+                                          doc.title,
+                                          doc.instrument_description[0]
+                                        )
                                       : doc.description
-                                      ? getInstrumentDescription(doc.title, doc.description[0])
+                                      ? getInstrumentDescription(
+                                          doc.title,
+                                          doc.description[0]
+                                        )
                                       : getInstrumentDescription(doc.title, "")
                                   }
                                   primaryLink={
@@ -1594,10 +1614,19 @@ const SearchPage = () => {
                                   title={doc.title ? doc.title : "-"}
                                   description={
                                     doc.instrument_host_description
-                                      ? getInstrumentHostDescription(doc.title, doc.instrument_host_description[0])
+                                      ? getInstrumentHostDescription(
+                                          doc.title,
+                                          doc.instrument_host_description[0]
+                                        )
                                       : doc.description
-                                      ? getInstrumentHostDescription(doc.title, doc.description[0])
-                                      : getInstrumentHostDescription(doc.title, "")
+                                      ? getInstrumentHostDescription(
+                                          doc.title,
+                                          doc.description[0]
+                                        )
+                                      : getInstrumentHostDescription(
+                                          doc.title,
+                                          ""
+                                        )
                                   }
                                   primaryLink={
                                     doc.identifier && doc.investigation_ref
@@ -1662,12 +1691,21 @@ const SearchPage = () => {
                                   title={doc.title ? doc.title : "-"}
                                   description={
                                     doc.investigation_description
-                                      ? getInvestigationDescription(doc.title, doc.investigation_description[0])
+                                      ? getInvestigationDescription(
+                                          doc.title,
+                                          doc.investigation_description[0]
+                                        )
                                       : doc.instrument_host_description
                                       ? doc.instrument_host_description[0]
                                       : doc.description
-                                      ? getInvestigationDescription(doc.title, doc.description[0])
-                                      : getInvestigationDescription(doc.title, "")
+                                      ? getInvestigationDescription(
+                                          doc.title,
+                                          doc.description[0]
+                                        )
+                                      : getInvestigationDescription(
+                                          doc.title,
+                                          ""
+                                        )
                                   }
                                   primaryLink={
                                     doc.identifier
@@ -1769,7 +1807,12 @@ const SearchPage = () => {
                                 <FeaturedLink
                                   title={doc.title ? doc.title : "-"}
                                   description={
-                                    doc.description ? getTargetDescription(doc.title, doc.description[0]) : "-"
+                                    doc.description
+                                      ? getTargetDescription(
+                                          doc.title,
+                                          doc.description[0]
+                                        )
+                                      : "-"
                                   }
                                   primaryLink={
                                     doc.identifier
@@ -1808,7 +1851,10 @@ const SearchPage = () => {
                                   title={doc.title ? doc.title : "-"}
                                   description={
                                     doc.telescope_description
-                                      ? getTelescopeDescription(doc.title, doc.telescope_description[0])
+                                      ? getTelescopeDescription(
+                                          doc.title,
+                                          doc.telescope_description[0]
+                                        )
                                       : getTelescopeDescription(doc.title, "")
                                   }
                                   primaryLink={

--- a/apps/frontend/src/pages/search/searchUtils.ts
+++ b/apps/frontend/src/pages/search/searchUtils.ts
@@ -391,6 +391,7 @@ const transformDocs = (data: SearchResultDocExpected[]) => {
 
     data.forEach((docExpected) => {
         const doc: SearchResultDoc = {
+            page_type: convertToStringArray(docExpected.page_type),
             file_ref_location: convertToStringArray(docExpected.file_ref_location),
             data_class:convertToStringArray(docExpected.data_class),
             description: convertToStringArray(docExpected.description),
@@ -426,7 +427,7 @@ const transformDocs = (data: SearchResultDocExpected[]) => {
             telescope_aperture: convertToStringArray(docExpected.telescope_aperture),
             instrument_name: convertToStringArray(docExpected.instrument_name),
             investigation_ref: convertToStringArray(docExpected.investigation_ref),
-            citation_publication_year: convertToStringArray(docExpected.citation_publication_year) 
+            citation_publication_year: convertToStringArray(docExpected.citation_publication_year),
         }
 
         if(docExpected.collection_type){

--- a/apps/frontend/src/types/solrSearchResponse.d.ts
+++ b/apps/frontend/src/types/solrSearchResponse.d.ts
@@ -49,7 +49,7 @@ type IdentifierNameResponse = {
 }
 
 type SearchResultDoc = {
-    page_type: string;
+    page_type: string[];
     file_ref_location: string[];
     data_class: string[];
     description: string[];
@@ -109,8 +109,6 @@ type SearchResultDoc = {
     instrument_name: string[];
     investigation_ref: string[];
     citation_publication_year: string[];
-
-
 }
 
 type IdentifierNameDoc = {

--- a/apps/frontend/src/types/solrSearchResponseExpected.d.ts
+++ b/apps/frontend/src/types/solrSearchResponseExpected.d.ts
@@ -49,6 +49,7 @@ type IdentifierNameResponse = {
 }
 
 export type SearchResultDoc = {
+    page_type: string | string[];
     file_ref_location: string | string[];
     data_class: string | string[];
     description: string | string[];


### PR DESCRIPTION
## 🗒️ Summary
-Removed checkboxes from single select filters. The text is now clickable instead of the checkbox.
-When a single filter is selected the options list becomes hidden. 
-Filter title has been added to the selected filter chip.

## ⚙️ Test Data and/or Report
Run normally with wds-react develop branch. Build tested and runs without issue.

## ♻️ Related Issues
fixes #141 


