### PR TITLE
Show Search Error #138

### DIFF
--- a/apps/frontend/src/components/Banner/SolrWarningBanner.tsx
+++ b/apps/frontend/src/components/Banner/SolrWarningBanner.tsx
@@ -51,6 +51,7 @@ export const SolrWarningBanner = (props: SolrWarningBannerProps) => {
   };
 
   useEffect(() => {
+    setIsErrorDetected(false);
     checkPageService();
   }, [location]);
 

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -57,6 +57,7 @@ import {
   TextField,
   Typography,
 } from "@nasapds/wds-react";
+import ErrorIcon from "@mui/icons-material/Error";
 import {
   calculatePaginationCount,
   calculateStartValue,
@@ -126,6 +127,7 @@ const SearchPage = () => {
   const [unmatchedFilters, setUnmatchedFilters] = useState<
     { name: string; identifier: string; parentName: string }[] | null
   >(null);
+  const [searchError, setSearchError] = useState(false);
 
   const organizeIdsByRefName = (
     ids: SolrIdentifierNameResponse,
@@ -783,7 +785,11 @@ const SearchPage = () => {
       targetNamesEndpoint,
     ];
     const titlePromises = titleUrls.map((url) =>
-      fetch(url).then((response) => response.json())
+      fetch(url)
+        .then((response) => response.json())
+        .catch(() => {
+          setSearchError(true);
+        })
     );
 
     Promise.all(titlePromises)
@@ -842,9 +848,9 @@ const SearchPage = () => {
               searchResults
             );
           })
-          .catch((error) => console.error("Error fetching data:", error));
+          .catch(() => console.error("Error fetching data:"));
       })
-      .catch((error) => console.error("Error fetching data:", error));
+      .catch(() => console.error("Error fetching data:"));
   };
 
   const doNavigate = (
@@ -1089,9 +1095,39 @@ const SearchPage = () => {
           </Container>
 
           {isLoading ? (
-            <Box className="pds-search-loader-container">
-              <Loader />
-            </Box>
+            searchError ? (
+              <Box className="pds-search-empty-container">
+                <br />
+
+                <Typography
+                  variant="h3"
+                  weight="bold"
+                  className="pds-search-empty-icon-div"
+                >
+                  <ErrorIcon />
+                  &nbsp;An Error Has Been Encountered.
+                </Typography>
+                <br />
+
+                <Typography variant="h4" weight="regular">
+                  Please try again later. If this issue persists you can let us
+                  know{" "}
+                  <a
+                    href={feedbackEmail}
+                    target="_top"
+                    className="pds-search-feedback-link"
+                  >
+                    here
+                  </a>
+                  .
+                </Typography>
+                <br />
+              </Box>
+            ) : (
+              <Box className="pds-search-loader-container">
+                <Loader />
+              </Box>
+            )
           ) : (
             <>
               {/*Search Options*/}
@@ -2004,7 +2040,11 @@ const SearchPage = () => {
                             <br />
                             <Typography variant="h4" weight="regular">
                               Not the results you expected?{" "}
-                              <a href={feedbackEmail} target="_top">
+                              <a
+                                href={feedbackEmail}
+                                target="_top"
+                                className="pds-search-feedback-link"
+                              >
                                 Give feedback
                               </a>
                             </Typography>
@@ -2027,7 +2067,11 @@ const SearchPage = () => {
                             <br />
                             <Typography variant="h4" weight="regular">
                               How can we improve your search experience?{" "}
-                              <a href={feedbackEmail} target="_top">
+                              <a
+                                href={feedbackEmail}
+                                target="_top"
+                                className="pds-search-feedback-link"
+                              >
                                 Give feedback
                               </a>
                             </Typography>
@@ -2068,7 +2112,11 @@ const SearchPage = () => {
                     <br />
                     <Typography variant="h4" weight="regular">
                       Not the results you expected?{" "}
-                      <a href={feedbackEmail} target="_top">
+                      <a
+                        href={feedbackEmail}
+                        target="_top"
+                        className="pds-search-feedback-link"
+                      >
                         Give feedback
                       </a>
                     </Typography>

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -459,14 +459,23 @@ const SearchPage = () => {
 
       setIsLoading(true);
 
-      const response = await fetch(url);
-      const data = await response.json();
-      const formattedResults = formatSearchResults(data);
+      let data;
+      setSearchError(false);
+      try {
+        const response = await fetch(url);
+        data = await response.json();
+      } catch (error) {
+        setSearchError(true);
+      }
 
-      setSearchResults(formattedResults);
-      setPaginationCount(calculatePaginationCount(formattedResults));
+      if (data) {
+        const formattedResults = formatSearchResults(data);
 
-      setAndRequestUrls(searchText, filters, formattedResults);
+        setSearchResults(formattedResults);
+        setPaginationCount(calculatePaginationCount(formattedResults));
+
+        setAndRequestUrls(searchText, filters, formattedResults);
+      }
     } else {
       setIsLoading(true);
       setIsEmptyState(true);

--- a/apps/frontend/src/pages/search/search.css
+++ b/apps/frontend/src/pages/search/search.css
@@ -118,3 +118,7 @@
     padding-left: 16px;
 }
 
+.pds-search-feedback-link{
+    color: var(--pds-secondary-blue-t1);
+}
+


### PR DESCRIPTION
## 🗒️ Summary
This PR makes it so that If the search service fails the search page will show an error message. This will replace the infinite loading icon.

## ⚙️ Test Data and/or Report
Run normally with wds-react develop branch. To test: set the network to off or change the service url to a non-existent one in order to produce an error during the fetch service call. 

## ♻️ Related Issues
fixes #138 


