### PR TITLE
Fix Direct Instrument Page Load Error #156

### DIFF
--- a/apps/frontend/src/pages/instruments/detail.tsx
+++ b/apps/frontend/src/pages/instruments/detail.tsx
@@ -197,11 +197,10 @@ const InstrumentDetailBody = (props:InstrumentDetailBodyProps) => {
   const investigationIsEmpty = () => {
     return Object.keys(investigation).length === 0;
   }
-
   const stats:Stats[] = [
     {
       label: "Investigation",
-      link: getLinkToInvestigationDetailPage({'lid': investigation[PDS4_INFO_MODEL.LID]}),
+      link: !investigationIsEmpty() ? getLinkToInvestigationDetailPage({'lid': investigation[PDS4_INFO_MODEL.LID]}) : "/",
       value: investigation[PDS4_INFO_MODEL.TITLE] ? investigation[PDS4_INFO_MODEL.TITLE] : "Not available at this time"
     },
     {


### PR DESCRIPTION
## 🗒️ Summary
This PR Fixes an issue where the instrument page attempting to load investigation link before it was loaded.

## ⚙️ Test Data and/or Report
Run normally with wds-react develop branch. Go directly to an instrument page for example: `http://localhost:5173/portal/instruments/urn--jaxa--darts--context--instrument--vco---ir1/data`


## ♻️ Related Issues
fixes #156 


