### PR TITLE
Fix Search String With Slash #145

### DIFF
--- a/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
+++ b/apps/frontend/src/components/HomeSearch/HomeSearch.tsx
@@ -432,7 +432,7 @@ export const HomeSearch = () => {
 
   const doNavigate = (searchText: string) => {
     const pathParams = {
-      searchText,
+      searchText: encodeURIComponent(searchText),
     };
 
     if (selectedFilters.length > 0) {

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -868,7 +868,7 @@ const SearchPage = () => {
     filters: string
   ) => {
     const pathParams = {
-      searchText,
+      searchText: encodeURIComponent(searchText),
     };
 
     let queryParams;


### PR DESCRIPTION
## 🗒️ Summary
This pull request fixes an issue where searching for strings that contain slashes would cause a 404.

## ⚙️ Test Data and/or Report
Run normally with wds-react develop branch. Search for CASSINI SS/S RPWS DERIVED LANGMUIR PROBE SWEEP V1.0, CO-SS/S-RPWS-5-LPSWEEP-V1.0 in the home page and search page. It will no longer return a 404.

## ♻️ Related Issues
fixes #145 


