### PR TITLE
Fixed email address for search page and updated secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,9 +125,9 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
+        "\\.secrets..*",
         "\\.git.*",
         "\\.pre-commit-config\\.yaml",
-        "\\.secrets..*",
         "node_modules"
       ]
     }
@@ -173,6 +173,16 @@
         "is_secret": false
       }
     ],
+    "apps/frontend/.env/.env": [
+      {
+        "type": "Email Address",
+        "filename": "apps/frontend/.env/.env",
+        "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
+        "is_verified": false,
+        "line_number": 5,
+        "is_secret": false
+      }
+    ],
     "apps/frontend/Dockerfile": [
       {
         "type": "Email Address",
@@ -182,67 +192,7 @@
         "line_number": 2,
         "is_secret": false
       }
-    ],
-    "apps/frontend/src/components/Footer/Footer.tsx": [
-      {
-        "type": "Email Address",
-        "filename": "apps/frontend/src/components/Footer/Footer.tsx",
-        "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
-        "is_verified": false,
-        "line_number": 66,
-        "is_secret": false
-      }
-    ],
-    "apps/frontend/src/components/Header/Header.tsx": [
-      {
-        "type": "Email Address",
-        "filename": "apps/frontend/src/components/Header/Header.tsx",
-        "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
-        "is_verified": false,
-        "line_number": 94,
-        "is_secret": false
-      }
-    ],
-    "apps/frontend/src/pages/home/index.tsx": [
-      {
-        "type": "Email Address",
-        "filename": "apps/frontend/src/pages/home/index.tsx",
-        "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
-        "is_verified": false,
-        "line_number": 155,
-        "is_secret": false
-      }
-    ],
-    "apps/frontend/src/pages/instruments/detail.tsx": [
-      {
-        "type": "Email Address",
-        "filename": "apps/frontend/src/pages/instruments/detail.tsx",
-        "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
-        "is_verified": false,
-        "line_number": 675,
-        "is_secret": false
-      }
-    ],
-    "apps/frontend/src/pages/investigations/detail.tsx": [
-      {
-        "type": "Email Address",
-        "filename": "apps/frontend/src/pages/investigations/detail.tsx",
-        "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
-        "is_verified": false,
-        "line_number": 692,
-        "is_secret": false
-      }
-    ],
-    "apps/frontend/src/pages/search/index.tsx": [
-      {
-        "type": "Email Address",
-        "filename": "apps/frontend/src/pages/search/index.tsx",
-        "hashed_secret": "914fec35ce8bfa1a067581032f26b053591ee38a",
-        "is_verified": false,
-        "line_number": 70,
-        "is_secret": false
-      }
     ]
   },
-  "generated_at": "2024-10-21T17:22:55Z"
+  "generated_at": "2025-02-11T22:52:09Z"
 }

--- a/apps/frontend/.env/.env
+++ b/apps/frontend/.env/.env
@@ -1,3 +1,5 @@
 # The number of milliseconds that need to pass before the data manager 
 # attempts to refetch data from OpenSearch
+VITE_APP_VERSION = ${npm_package_version}
 VITE_DATA_RETENTION_PERIOD = 14400000
+VITE_SUPPORT_EMAIL = pds-operator@jpl.nasa.gov

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pds-portal-frontend",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/frontend/src/AppConfig.ts
+++ b/apps/frontend/src/AppConfig.ts
@@ -3,8 +3,9 @@ import { BannerProps } from "@nasapds/wds-react";
 
 type AppConfig = {
   GENERAL: {
-    VERSION:string
+    APP_VERSION:string
     BANNER_MESSAGES:Array<BannerProps>
+    SUPPORT_EMAIL:string
   }
   SETTINGS: {
     SORT_ORDER: {
@@ -16,19 +17,20 @@ type AppConfig = {
 export const APP_CONFIG:AppConfig = {
 
   GENERAL: {
-    VERSION: import.meta.env.VITE_APP_VERSION,
+    APP_VERSION: import.meta.env.VITE_APP_VERSION,
     BANNER_MESSAGES: [
       {
         title: "This site is in BETA",
         message: "As we work on improving the site, please keep in mind that it is still under development and may have limitations.",
         link:{
           title: "Give Feedback",
-          href: "mailto:pds-operator@jpl.nasa.gov",
+          href: `mailto:${import.meta.env.VITE_SUPPORT_EMAIL}`,
           type: "internal"
         },
         variant: "info"
       }
-    ]
+    ],
+    SUPPORT_EMAIL: import.meta.env.VITE_SUPPORT_EMAIL
   },
 
   SETTINGS: {

--- a/apps/frontend/src/components/Footer/Footer.tsx
+++ b/apps/frontend/src/components/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import { APP_CONFIG } from "src/AppConfig";
 import { FooterLink, Footer } from "@nasapds/wds-react";
 
 function PortalFooter() {
@@ -63,7 +64,7 @@ function PortalFooter() {
     {
       id: "",
       label: "Give Feedback",
-      href: "mailto:pds-operator@jpl.nasa.gov"
+      href: `mailto:${APP_CONFIG.GENERAL.SUPPORT_EMAIL}`
     },
   ];
 

--- a/apps/frontend/src/components/Header/Header.tsx
+++ b/apps/frontend/src/components/Header/Header.tsx
@@ -1,3 +1,4 @@
+import { APP_CONFIG } from "src/AppConfig";
 import { Header } from "@nasapds/wds-react";
 import { NavItems } from "@nasapds/wds-react";
 
@@ -91,7 +92,7 @@ const navItems: NavItems[] = [
   {
     id: "give-feedback",
     label: "Give Feedback",
-    href: "mailto:pds-operator@jpl.nasa.gov",
+    href: `mailto:${APP_CONFIG.GENERAL.SUPPORT_EMAIL}`,
   },
 ];
 

--- a/apps/frontend/src/pages/home/index.tsx
+++ b/apps/frontend/src/pages/home/index.tsx
@@ -1,3 +1,4 @@
+import { APP_CONFIG } from "src/AppConfig";
 import { DocumentMeta } from "src/components/DocumentMeta/DocumentMeta";
 import { ExploreTopicsSixUp, ExploreTopicsSixUpProps } from "src/components/ExploreTopicsSixUp";
 import { SubmitDataQuickLinks } from "src/components/SubmitDataQuickLinks";
@@ -152,7 +153,7 @@ const HomePage = () => {
           "We are thrilled to announce the beta release of our newly redesigned NASA Planetary Data System (PDS) website! Please give us feedback to improve your experience"
         }
         imageSrc={"/assets/images/homepage-hero.jpg"}
-        buttonLink={"mailto:pds-operator@jpl.nasa.gov"}
+        buttonLink={`mailto:${APP_CONFIG.GENERAL.SUPPORT_EMAIL}`}
         buttonText={"Give Feedback"}
       />
     <HomeSearch />

--- a/apps/frontend/src/pages/instruments/detail.tsx
+++ b/apps/frontend/src/pages/instruments/detail.tsx
@@ -673,14 +673,14 @@ const InstrumentDetailBody = (props:InstrumentDetailBodyProps) => {
 
                           }
                           <Box style={{marginTop: "36px"}} >
-                            <Typography variant="h5" weight="semibold" component={"span"}>We are working to provide additional metadata when possible. Please contact <Link to="mailto:pds-operator@jpl.nasa.gov" style={{color: "#1C67E3"}}>PDS Help Desk</Link> for assistance.</Typography>
+                            <Typography variant="h5" weight="semibold" component={"span"}>We are working to provide additional metadata when possible. Please contact <Link to={`mailto:${APP_CONFIG.GENERAL.SUPPORT_EMAIL}`} style={{color: "#1C67E3"}}>PDS Help Desk</Link> for assistance.</Typography>
                           </Box>
                         </>
                       }
                     </Stack>
 
                     <Box style={{marginTop: "24px", display: collections.length === 0 ? "block" : "none"}}>
-                      <Typography variant="h4" weight="semibold" component={"span"}>No data collections available at this time. Please check back later or contact the <Link to="mailto:pds-operator@jpl.nasa.gov" style={{color: "#1C67E3"}}>PDS Help Desk</Link> for assistance.</Typography>
+                      <Typography variant="h4" weight="semibold" component={"span"}>No data collections available at this time. Please check back later or contact the <Link to={`mailto:${APP_CONFIG.GENERAL.SUPPORT_EMAIL}`} style={{color: "#1C67E3"}}>PDS Help Desk</Link> for assistance.</Typography>
                     </Box>
 
                   </Grid>

--- a/apps/frontend/src/pages/investigations/detail.tsx
+++ b/apps/frontend/src/pages/investigations/detail.tsx
@@ -689,7 +689,7 @@ const InvestigationDetailBody = (props:InvestigationDetailBodyProps) => {
                     <Stack>
                       {
                         instrumentTypes.length === 0 && <>
-                          <Typography variant="h4" weight="semibold" component={"span"}>No instruments available at this time. Please check back later or contact the <Link to="mailto:pds-operator@jpl.nasa.gov" style={{color: "#1C67E3"}}>PDS Help Desk</Link> for assistance.</Typography>
+                          <Typography variant="h4" weight="semibold" component={"span"}>No instruments available at this time. Please check back later or contact the <Link to={`mailto:${APP_CONFIG.GENERAL.SUPPORT_EMAIL}`} style={{color: "#1C67E3"}}>PDS Help Desk</Link> for assistance.</Typography>
                         </>
                       }
                       {

--- a/apps/frontend/src/pages/search/index.tsx
+++ b/apps/frontend/src/pages/search/index.tsx
@@ -77,10 +77,11 @@ import "./search.css";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 import { DocumentMeta } from "src/components/DocumentMeta/DocumentMeta";
+import { APP_CONFIG } from "src/AppConfig";
 
 const pdsSite = "https://pds.nasa.gov";
 const doiSite = "https://doi.org";
-const feedbackEmail = "mailto:example@example.com";
+const feedbackEmail = `mailto:${APP_CONFIG.GENERAL.SUPPORT_EMAIL}`;
 const solrEndpoint = "https://pds.nasa.gov/services/search/search";
 const getFiltersQuery =
   "&qt=keyword&rows=0&facet=on&facet.field=investigation_ref&facet.field=instrument_ref&facet.field=target_ref&facet.field=page_type&wt=json&facet.limit=-1";


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

Updated env and app configuration so that our support email address can be stored in one place and referenced wherever it is needed. Also fixed the email address displayed to users when a search error occurs using this centralized email address.

Since this change affects our secrets, I also updated and audited our secrets baseline to squash previously reported errors by our GH secrets detection workflow.


## ⚙️ Test Data and/or Report

Tested by running codebase locally and verified that production cold builds do not generate an error.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

- Fixes #142
- Fixes #161 

