### PR TITLE
Bumped @nasapds/wds-react version and updated site's last updated date.

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "@fontsource/public-sans": "^5.0.18",
         "@mui/icons-material": "^5.15.11",
         "@mui/material": "^5.15.11",
-        "@nasapds/wds-react": "^0.0.5",
+        "@nasapds/wds-react": "^0.0.6",
         "@reduxjs/toolkit": "^2.2.1",
         "axios": "^1.6.7",
         "classnames": "^2.5.1",
@@ -893,16 +893,22 @@
       "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
     },
     "node_modules/@fontsource-variable/inter": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.1.1.tgz",
-      "integrity": "sha512-OpXFTmiH6tHkYijMvQTycFKBLK4X+SRV6tet1m4YOUH7SzIIlMqDja+ocDtiCA72UthBH/vF+3ZtlMr2rN/wIw==",
-      "license": "OFL-1.1"
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.5.tgz",
+      "integrity": "sha512-TrWffUAFOnT8zroE9YmGybagoOgM/HjRqMQ8k9R0vVgXlnUh/vnpbGPAS/Caz1KIlOPnPGh6fvJbb7DHbFCncA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@fontsource-variable/public-sans": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/public-sans/-/public-sans-5.1.2.tgz",
-      "integrity": "sha512-D4BaUhRY52xoVJw24gOVJymDBHoezdv3X2Rot9iYsHieEuvu8mwBNTSqBJvS6wlMZo2i834azXKllxRYE0C6fg==",
-      "license": "OFL-1.1"
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/public-sans/-/public-sans-5.2.5.tgz",
+      "integrity": "sha512-/guMye9ATKBlF7FuQeTJqW3RBilKmgeno6O2HXNEaRHP1JpfpG4oG8HwX8Mf0w6UHHE2b4monggJr1IfR4NhuA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@fontsource/dm-mono": {
       "version": "5.1.1",
@@ -1221,9 +1227,9 @@
       }
     },
     "node_modules/@nasapds/wds": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@nasapds/wds/-/wds-0.0.4.tgz",
-      "integrity": "sha512-aXD0hGqcRzOG/T8qmkhXsiFH/QHd2KZu3qFYPlIRm4Vjueredx/Zj4aOrvFFJHjkSakgvVCSEoFLutkr6P37Fg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@nasapds/wds/-/wds-0.0.5.tgz",
+      "integrity": "sha512-dQbJ5cQPqkkRd9BARlEb7E0PkGu2Uiq9rj3DlPZXb7e6vTJZ9G/mJNBbXXV0PKMDuEvdImjwHPcE3rTp+n8UTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.1.1",
@@ -1232,12 +1238,12 @@
       }
     },
     "node_modules/@nasapds/wds-react": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@nasapds/wds-react/-/wds-react-0.0.5.tgz",
-      "integrity": "sha512-8p4jQcrVdd0MulwXOqLDJO1pBtiFYhhRlURbEeWJ7SUdrOdr7BsVWwY3g+Ht7fmtdEvGKrPYlRnIQ0DEjL1UfQ==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@nasapds/wds-react/-/wds-react-0.0.6.tgz",
+      "integrity": "sha512-ygRzquYgi6TXalct6HtZSJF7ZJVCVOXZOe25Vt5INZQluxHiiJ9N3+eNUyzynqsGBIVnykxoiICq1wf8fY0wxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nasapds/wds": "^0.0.4"
+        "@nasapds/wds": "^0.0.5"
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -18,7 +18,7 @@
     "@fontsource/public-sans": "^5.0.18",
     "@mui/icons-material": "^5.15.11",
     "@mui/material": "^5.15.11",
-    "@nasapds/wds-react": "^0.0.5",
+    "@nasapds/wds-react": "^0.0.6",
     "@reduxjs/toolkit": "^2.2.1",
     "axios": "^1.6.7",
     "classnames": "^2.5.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pds-portal-frontend",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/frontend/src/components/Footer/Footer.tsx
+++ b/apps/frontend/src/components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import { FooterLink, Footer } from "@nasapds/wds-react";
 
 function PortalFooter() {
 
-  const pageLastUpdated="Feb. 11, 2025"
+  const pageLastUpdated="Mar. 4, 2025"
 
   const primaryLinks:FooterLink[] = [
     {


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

This PR addresses:
- bumped `@nasapds/wds-react` to `0.0.6`
- updated last updated date value in footer
- bumped `portal-wp` package version to `0.0.7`


## ⚙️ Test Data and/or Report

Tested locally and verified that no build errors were generated by `npm run build`.
